### PR TITLE
Upgraded to biolink 2.2.6

### DIFF
--- a/biolink_model_pydantic/__init__.py
+++ b/biolink_model_pydantic/__init__.py
@@ -1,2 +1,2 @@
 """Pydantic dataclasses for the Biolink model"""
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/biolink_model_pydantic/model.py
+++ b/biolink_model_pydantic/model.py
@@ -1,5 +1,5 @@
 # Auto generated from biolink-model.yaml by pydanticgen.py version: 0.9.0
-# Generation date: 2021-10-21 15:08
+# Generation date: 2021-10-25 12:16
 # Schema: Biolink-Model
 #
 # id: https://w3id.org/biolink/biolink-model
@@ -844,6 +844,7 @@ valid_prefix = [
     "SDBS",
     "SEED",
     "SEED_COMPOUND",
+    "SEED_REACTION",
     "SEMMEDDB",
     "SEP",
     "SEPIO",
@@ -1056,7 +1057,7 @@ valid_prefix = [
     "void",
     "wgs",
     "xml",
-    "xsd",
+    "xsd"
 ]
 
 
@@ -1149,12 +1150,8 @@ class PredicateType(str, Enum):
     acts_upstream_of = "biolink:acts_upstream_of"
     acts_upstream_of_negative_effect = "biolink:acts_upstream_of_negative_effect"
     acts_upstream_of_or_within = "biolink:acts_upstream_of_or_within"
-    acts_upstream_of_or_within_negative_effect = (
-        "biolink:acts_upstream_of_or_within_negative_effect"
-    )
-    acts_upstream_of_or_within_positive_effect = (
-        "biolink:acts_upstream_of_or_within_positive_effect"
-    )
+    acts_upstream_of_or_within_negative_effect = "biolink:acts_upstream_of_or_within_negative_effect"
+    acts_upstream_of_or_within_positive_effect = "biolink:acts_upstream_of_or_within_positive_effect"
     acts_upstream_of_positive_effect = "biolink:acts_upstream_of_positive_effect"
     adverse_event_caused_by = "biolink:adverse_event_caused_by"
     affected_by = "biolink:affected_by"
@@ -1192,6 +1189,7 @@ class PredicateType(str, Enum):
     chemically_interacts_with = "biolink:chemically_interacts_with"
     chemically_similar_to = "biolink:chemically_similar_to"
     close_match = "biolink:close_match"
+    co_occurs_in_literature_with = "biolink:co_occurs_in_literature_with"
     coexists_with = "biolink:coexists_with"
     coexpressed_with = "biolink:coexpressed_with"
     colocalizes_with = "biolink:colocalizes_with"
@@ -1288,9 +1286,7 @@ class PredicateType(str, Enum):
     has_phenotype = "biolink:has_phenotype"
     has_positive_upstream_actor = "biolink:has_positive_upstream_actor"
     has_positive_upstream_or_within_actor = "biolink:has_positive_upstream_or_within_actor"
-    has_real_world_evidence_of_association_with = (
-        "biolink:has_real_world_evidence_of_association_with"
-    )
+    has_real_world_evidence_of_association_with = "biolink:has_real_world_evidence_of_association_with"
     has_sequence_location = "biolink:has_sequence_location"
     has_sequence_variant = "biolink:has_sequence_variant"
     has_splice_site_variant = "biolink:has_splice_site_variant"
@@ -1398,6 +1394,8 @@ class PredicateType(str, Enum):
     publisher = "biolink:publisher"
     related_condition = "biolink:related_condition"
     related_to = "biolink:related_to"
+    related_to_at_concept_level = "biolink:related_to_at_concept_level"
+    related_to_at_instance_level = "biolink:related_to_at_instance_level"
     response_affected_by = "biolink:response_affected_by"
     response_decreased_by = "biolink:response_decreased_by"
     response_increased_by = "biolink:response_increased_by"
@@ -1436,7 +1434,6 @@ class PredicateType(str, Enum):
     variant_part_of = "biolink:variant_part_of"
     xenologous_to = "biolink:xenologous_to"
 
-
 Predicate = namedtuple(
     'biolink_predicate', [pred.value.replace('biolink:', '') for pred in PredicateType]
 )(*[pred.value for pred in PredicateType])
@@ -1450,7 +1447,6 @@ class LogicalInterpretationEnum(str, Enum):
     AllSome = "AllSome"
     InverseAllSome = "InverseAllSome"
 
-
 @unique
 class ReactionDirectionEnum(str, Enum):
 
@@ -1459,46 +1455,38 @@ class ReactionDirectionEnum(str, Enum):
     bidirectional = "bidirectional"
     neutral = "neutral"
 
-
 @unique
 class ReactionSideEnum(str, Enum):
 
     left = "left"
     right = "right"
 
-
 @unique
 class PhaseEnum(str, Enum):
     """
     phase
     """
-
     value_0 = "0"
     value_1 = "1"
     value_2 = "2"
-
 
 @unique
 class StrandEnum(str, Enum):
     """
     strand
     """
-
     value_0 = "+"
     value_1 = "-"
     value_2 = "."
     value_3 = "?"
-
 
 @unique
 class SequenceEnum(str, Enum):
     """
     type of sequence
     """
-
     NA = "NA"
     AA = "AA"
-
 
 @unique
 class PredicateQualifierEnum(str, Enum):
@@ -1506,7 +1494,6 @@ class PredicateQualifierEnum(str, Enum):
     constrained list of qualifying terms that soften or expand the definition of the predicate used. can be used to
     constrain or qualify any predicate (any child of related_to).
     """
-
     predicted = "predicted"
     possibly = "possibly"
     hypothesized = "hypothesized"
@@ -1514,13 +1501,11 @@ class PredicateQualifierEnum(str, Enum):
     value_4 = "supported by real-world evidence"
     value_5 = "supported by clinical evidence"
 
-
 @unique
 class DrugAvailabilityEnum(str, Enum):
 
     value_0 = "over the counter"
     prescription = "prescription"
-
 
 @unique
 class FDAApprovalStatusEnum(str, Enum):
@@ -1541,9 +1526,7 @@ class FDAApprovalStatusEnum(str, Enum):
     value_13 = "Regular FDA Approval"
     value_14 = "Post-Approval Withdrawal"
 
-
 # Classes
-
 
 @dataclass(config=PydanticConfig)
 class OntologyClass:
@@ -1555,7 +1538,13 @@ class OntologyClass:
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = ["MESH", "UMLS", "KEGG.BRITE"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "MESH",
+        "UMLS",
+        "KEGG.BRITE"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -1563,6 +1552,8 @@ class Annotation:
     """
     Biolink Model root class for entity annotations.
     """
+
+    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1579,6 +1570,7 @@ class QuantityValue(Annotation):
     has_numeric_value: Optional[Union[float, float]] = None
 
 
+
 @dataclass(config=PydanticConfig)
 class Attribute(Annotation, OntologyClass):
     """
@@ -1588,13 +1580,16 @@ class Attribute(Annotation, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Attribute"
-    _id_prefixes: ClassVar[List[str]] = ["EDAM-DATA", "EDAM-FORMAT", "EDAM-OPERATION", "EDAM-TOPIC"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "EDAM-DATA",
+        "EDAM-FORMAT",
+        "EDAM-OPERATION",
+        "EDAM-TOPIC"
+    ]
 
     has_attribute_type: Union[str, OntologyClass] = None
     name: Optional[Union[str, LabelType]] = None
-    has_quantitative_value: Optional[
-        Union[List[Union[str, QuantityValue]], Union[str, QuantityValue]]
-    ] = field(default_factory=list)
+    has_quantitative_value: Optional[Union[List[Union[str, QuantityValue]], Union[str, QuantityValue]]] = field(default_factory=list)
     has_qualitative_value: Optional[Union[URIorCURIE, NamedThing]] = None
     iri: Optional[IriType] = None
     source: Optional[Union[str, LabelType]] = None
@@ -1623,6 +1618,8 @@ class BiologicalSex(Attribute):
     _category: ClassVar[str] = "BiologicalSex"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class PhenotypicSex(BiologicalSex):
     """
@@ -1631,6 +1628,8 @@ class PhenotypicSex(BiologicalSex):
 
     # Class Variables
     _category: ClassVar[str] = "PhenotypicSex"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -1644,6 +1643,8 @@ class GenotypicSex(BiologicalSex):
     _category: ClassVar[str] = "GenotypicSex"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class SeverityValue(Attribute):
     """
@@ -1652,6 +1653,8 @@ class SeverityValue(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "SeverityValue"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -1679,6 +1682,8 @@ class PathognomonicityQuantifier(SpecificityQuantifier):
     feature implies the existence of the disease
     """
 
+    pass
+
 
 @dataclass(config=PydanticConfig)
 class FrequencyQuantifier(RelationshipQuantifier):
@@ -1686,6 +1691,7 @@ class FrequencyQuantifier(RelationshipQuantifier):
     has_total: Optional[Union[int, int]] = None
     has_quotient: Optional[Union[float, float]] = None
     has_percentage: Optional[Union[float, float]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -1699,7 +1705,6 @@ class Entity:
     """
     Root Biolink Model class for all things and informational relationships, real or imagined.
     """
-
     id: URIorCURIE = None
     iri: Optional[IriType] = None
     category: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
@@ -1708,9 +1713,7 @@ class Entity:
     description: Optional[Union[str, NarrativeText]] = None
     source: Optional[Union[str, LabelType]] = None
     provided_by: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
-    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(
-        default_factory=list
-    )
+    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(default_factory=list)
 
     # Validators
 
@@ -1745,6 +1748,7 @@ class Entity:
             )
 
 
+
 @dataclass(config=PydanticConfig)
 class NamedThing(Entity):
     """
@@ -1775,11 +1779,15 @@ class RelationshipType(OntologyClass):
     _category: ClassVar[str] = "RelationshipType"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class GeneOntologyClass(OntologyClass):
     """
     an ontology class that describes a functional aspect of a gene, gene prodoct or complex
     """
+
+    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1787,6 +1795,8 @@ class UnclassifiedOntologyClass(OntologyClass):
     """
     this is used for nodes that are taken from an ontology but are not typed using an existing biolink class
     """
+
+    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1797,7 +1807,11 @@ class TaxonomicRank(OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "TaxonomicRank"
-    _id_prefixes: ClassVar[List[str]] = ["TAXRANK"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "TAXRANK"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -1809,12 +1823,13 @@ class OrganismTaxon(NamedThing):
 
     # Class Variables
     _category: ClassVar[str] = "OrganismTaxon"
-    _id_prefixes: ClassVar[List[str]] = ["NCBITaxon", "MESH"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "NCBITaxon",
+        "MESH"
+    ]
 
     has_taxonomic_rank: Optional[Union[str, TaxonomicRank]] = None
-    subclass_of: Optional[
-        Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]
-    ] = field(default_factory=list)
+    subclass_of: Optional[Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]] = field(default_factory=list)
 
     # Validators
 
@@ -1833,6 +1848,8 @@ class Event(NamedThing):
     _category: ClassVar[str] = "Event"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class AdministrativeEntity(NamedThing):
 
@@ -1847,12 +1864,17 @@ class Agent(AdministrativeEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Agent"
-    _id_prefixes: ClassVar[List[str]] = ["isbn", "ORCID", "ScopusID", "ResearchID", "GSID", "isni"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "isbn",
+        "ORCID",
+        "ScopusID",
+        "ResearchID",
+        "GSID",
+        "isni"
+    ]
 
     id: URIorCURIE = None
-    affiliation: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
-        default_factory=list
-    )
+    affiliation: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
     address: Optional[Union[str, str]] = None
     name: Optional[Union[str, LabelType]] = None
 
@@ -1876,12 +1898,15 @@ class InformationContentEntity(NamedThing):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = ["doi"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "doi"
+    ]
 
     license: Optional[Union[str, str]] = None
     rights: Optional[Union[str, str]] = None
     format: Optional[Union[str, str]] = None
     creation_date: Optional[Union[str, XSDDate]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -1894,6 +1919,8 @@ class Dataset(InformationContentEntity):
     _category: ClassVar[str] = "Dataset"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class DatasetDistribution(InformationContentEntity):
     """
@@ -1904,6 +1931,7 @@ class DatasetDistribution(InformationContentEntity):
     _category: ClassVar[str] = "DatasetDistribution"
 
     distribution_download_url: Optional[Union[str, str]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -1945,6 +1973,7 @@ class DatasetSummary(InformationContentEntity):
     source_logo: Optional[Union[str, str]] = None
 
 
+
 @dataclass(config=PydanticConfig)
 class ConfidenceLevel(InformationContentEntity):
     """
@@ -1955,6 +1984,8 @@ class ConfidenceLevel(InformationContentEntity):
     _category: ClassVar[str] = "ConfidenceLevel"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class EvidenceType(InformationContentEntity):
     """
@@ -1963,6 +1994,8 @@ class EvidenceType(InformationContentEntity):
 
     # Class Variables
     _category: ClassVar[str] = "EvidenceType"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -1979,6 +2012,8 @@ class InformationResource(InformationContentEntity):
     _category: ClassVar[str] = "InformationResource"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Publication(InformationContentEntity):
     """
@@ -1990,7 +2025,9 @@ class Publication(InformationContentEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Publication"
-    _id_prefixes: ClassVar[List[str]] = ["NLMID"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "NLMID"
+    ]
 
     id: URIorCURIE = None
     type: Union[str, str] = None
@@ -1998,9 +2035,7 @@ class Publication(InformationContentEntity):
     pages: Optional[Union[List[Union[str, str]], Union[str, str]]] = field(default_factory=list)
     summary: Optional[Union[str, str]] = None
     keywords: Optional[Union[List[Union[str, str]], Union[str, str]]] = field(default_factory=list)
-    mesh_terms: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
-        default_factory=list
-    )
+    mesh_terms: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
     xref: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
     name: Optional[Union[str, LabelType]] = None
 
@@ -2046,7 +2081,10 @@ class Book(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Book"
-    _id_prefixes: ClassVar[List[str]] = ["isbn", "NLMID"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "isbn",
+        "NLMID"
+    ]
 
     id: URIorCURIE = None
     type: Union[str, str] = None
@@ -2092,7 +2130,10 @@ class Serial(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Serial"
-    _id_prefixes: ClassVar[List[str]] = ["issn", "NLMID"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "issn",
+        "NLMID"
+    ]
 
     id: URIorCURIE = None
     type: Union[str, str] = None
@@ -2119,7 +2160,9 @@ class Article(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Article"
-    _id_prefixes: ClassVar[List[str]] = ["PMID"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "PMID"
+    ]
 
     published_in: Union[str, URIorCURIE] = None
     iso_abbreviation: Optional[Union[str, str]] = None
@@ -2141,12 +2184,16 @@ class PhysicalEssenceOrOccurrent:
     Either a physical or processual entity.
     """
 
+    pass
+
 
 @dataclass(config=PydanticConfig)
 class PhysicalEssence(PhysicalEssenceOrOccurrent):
     """
     Semantic mixin concept.  Pertains to entities that have physical properties such as mass, volume, or charge.
     """
+
+    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2159,11 +2206,15 @@ class PhysicalEntity(NamedThing, PhysicalEssence):
     _category: ClassVar[str] = "PhysicalEntity"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Occurrent(PhysicalEssenceOrOccurrent):
     """
     A processual entity.
     """
+
+    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2171,6 +2222,8 @@ class ActivityAndBehavior(Occurrent):
     """
     Activity or behavior of any independent integral living, organization or mechanical actor in the world
     """
+
+    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2184,6 +2237,8 @@ class Activity(NamedThing, ActivityAndBehavior):
     _category: ClassVar[str] = "Activity"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Procedure(NamedThing, ActivityAndBehavior):
     """
@@ -2192,6 +2247,8 @@ class Procedure(NamedThing, ActivityAndBehavior):
 
     # Class Variables
     _category: ClassVar[str] = "Procedure"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2204,6 +2261,8 @@ class Phenomenon(NamedThing, Occurrent):
     _category: ClassVar[str] = "Phenomenon"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Device(NamedThing):
     """
@@ -2214,11 +2273,15 @@ class Device(NamedThing):
     _category: ClassVar[str] = "Device"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class SubjectOfInvestigation:
     """
     An entity that has the role of being studied in an investigation, study, or experiment
     """
+
+    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2231,7 +2294,12 @@ class MaterialSample(PhysicalEntity, SubjectOfInvestigation):
 
     # Class Variables
     _category: ClassVar[str] = "MaterialSample"
-    _id_prefixes: ClassVar[List[str]] = ["BIOSAMPLE", "GOLD.META"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "BIOSAMPLE",
+        "GOLD.META"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2244,6 +2312,8 @@ class PlanetaryEntity(NamedThing):
     _category: ClassVar[str] = "PlanetaryEntity"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class EnvironmentalProcess(PlanetaryEntity, Occurrent):
 
@@ -2251,11 +2321,15 @@ class EnvironmentalProcess(PlanetaryEntity, Occurrent):
     _category: ClassVar[str] = "EnvironmentalProcess"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class EnvironmentalFeature(PlanetaryEntity):
 
     # Class Variables
     _category: ClassVar[str] = "EnvironmentalFeature"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2271,6 +2345,7 @@ class GeographicLocation(PlanetaryEntity):
     longitude: Optional[Union[float, float]] = None
 
 
+
 @dataclass(config=PydanticConfig)
 class GeographicLocationAtTime(GeographicLocation):
     """
@@ -2281,6 +2356,7 @@ class GeographicLocationAtTime(GeographicLocation):
     _category: ClassVar[str] = "GeographicLocationAtTime"
 
     timepoint: Optional[Union[str, TimeType]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2295,10 +2371,7 @@ class ThingWithTaxon:
     A mixin that can be used on any entity that can be taxonomically classified. This includes individual organisms;
     genes, their products and other molecular entities; body parts; biological processes
     """
-
-    in_taxon: Optional[
-        Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]
-    ] = field(default_factory=list)
+    in_taxon: Optional[Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]] = field(default_factory=list)
 
     # Validators
 
@@ -2312,11 +2385,14 @@ class GenomicEntity(ThingWithTaxon):
     has_biological_sequence: Optional[Union[str, BiologicalSequence]] = None
 
 
+
 @dataclass(config=PydanticConfig)
 class ChemicalSubstance:
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalSubstance"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2328,23 +2404,14 @@ class BiologicalProcessOrActivity(BiologicalEntity, Occurrent, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "BiologicalProcessOrActivity"
-    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "GO",
+        "REACT"
+    ]
 
-    has_input: Optional[
-        Union[
-            List[Union[URIorCURIE, BiologicalProcessOrActivity]],
-            Union[URIorCURIE, BiologicalProcessOrActivity],
-        ]
-    ] = field(default_factory=list)
-    has_output: Optional[
-        Union[
-            List[Union[URIorCURIE, BiologicalProcessOrActivity]],
-            Union[URIorCURIE, BiologicalProcessOrActivity],
-        ]
-    ] = field(default_factory=list)
-    enabled_by: Optional[
-        Union[List[Union[URIorCURIE, PhysicalEntity]], Union[URIorCURIE, PhysicalEntity]]
-    ] = field(default_factory=list)
+    has_input: Optional[Union[List[Union[URIorCURIE, BiologicalProcessOrActivity]], Union[URIorCURIE, BiologicalProcessOrActivity]]] = field(default_factory=list)
+    has_output: Optional[Union[List[Union[URIorCURIE, BiologicalProcessOrActivity]], Union[URIorCURIE, BiologicalProcessOrActivity]]] = field(default_factory=list)
+    enabled_by: Optional[Union[List[Union[URIorCURIE, PhysicalEntity]], Union[URIorCURIE, PhysicalEntity]]] = field(default_factory=list)
 
     # Validators
 
@@ -2379,19 +2446,16 @@ class MolecularActivity(BiologicalProcessOrActivity, Occurrent, OntologyClass):
         "KEGG.REACTION",
         "KEGG.RCLASS",
         "KEGG.ENZYME",
+        "KEGG.ORTHOLOGY",
         "UMLS",
         "BIGG.REACTION",
+        "SEED.REACTION",
+        "METANETX.REACTION"
     ]
 
-    has_input: Optional[
-        Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]
-    ] = field(default_factory=list)
-    has_output: Optional[
-        Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]
-    ] = field(default_factory=list)
-    enabled_by: Optional[
-        Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]
-    ] = field(default_factory=list)
+    has_input: Optional[Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]] = field(default_factory=list)
+    has_output: Optional[Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]] = field(default_factory=list)
+    enabled_by: Optional[Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]] = field(default_factory=list)
 
     # Validators
 
@@ -2416,7 +2480,14 @@ class BiologicalProcess(BiologicalProcessOrActivity, Occurrent, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "BiologicalProcess"
-    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT", "MetaCyc", "KEGG.MODULE"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "GO",
+        "REACT",
+        "MetaCyc",
+        "KEGG.MODULE"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2434,7 +2505,10 @@ class Pathway(BiologicalProcess, OntologyClass):
         "WIKIPATHWAYS",
         "FB",
         "PANTHER.PATHWAY",
+        "KEGG.PATHWAY"
     ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2442,7 +2516,12 @@ class PhysiologicalProcess(BiologicalProcess, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "PhysiologicalProcess"
-    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "GO",
+        "REACT"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2450,6 +2529,8 @@ class Behavior(BiologicalProcess, ActivityAndBehavior, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Behavior"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2462,6 +2543,8 @@ class OrganismAttribute(Attribute):
     _category: ClassVar[str] = "OrganismAttribute"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class PhenotypicQuality(OrganismAttribute):
     """
@@ -2470,6 +2553,8 @@ class PhenotypicQuality(OrganismAttribute):
 
     # Class Variables
     _category: ClassVar[str] = "PhenotypicQuality"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2483,16 +2568,15 @@ class Inheritance(OrganismAttribute):
     _category: ClassVar[str] = "Inheritance"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class OrganismalEntity(BiologicalEntity):
     """
     A named entity that is either a part of an organism, a whole organism, population or clade of organisms, excluding
     chemical entities
     """
-
-    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(
-        default_factory=list
-    )
+    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(default_factory=list)
 
     # Validators
 
@@ -2511,6 +2595,8 @@ class LifeStage(OrganismalEntity, ThingWithTaxon):
     _category: ClassVar[str] = "LifeStage"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class IndividualOrganism(OrganismalEntity, ThingWithTaxon):
     """
@@ -2520,7 +2606,11 @@ class IndividualOrganism(OrganismalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "IndividualOrganism"
-    _id_prefixes: ClassVar[List[str]] = ["ORCID"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "ORCID"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2533,7 +2623,11 @@ class PopulationOfIndividualOrganisms(OrganismalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "PopulationOfIndividualOrganisms"
-    _id_prefixes: ClassVar[List[str]] = ["HANCESTRO"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "HANCESTRO"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2546,6 +2640,8 @@ class StudyPopulation(PopulationOfIndividualOrganisms):
     _category: ClassVar[str] = "StudyPopulation"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class DiseaseOrPhenotypicFeature(BiologicalEntity, ThingWithTaxon):
     """
@@ -2555,6 +2651,8 @@ class DiseaseOrPhenotypicFeature(BiologicalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeature"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2579,8 +2677,10 @@ class Disease(DiseaseOrPhenotypicFeature):
         "ICD0",
         "KEGG.DISEASE",
         "HP",
-        "MP",
+        "MP"
     ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2603,8 +2703,10 @@ class PhenotypicFeature(DiseaseOrPhenotypicFeature):
         "SNOMEDCT",
         "MESH",
         "XPO",
-        "FYPO",
+        "FYPO"
     ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2617,6 +2719,8 @@ class BehavioralFeature(PhenotypicFeature):
     _category: ClassVar[str] = "BehavioralFeature"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class AnatomicalEntity(OrganismalEntity, ThingWithTaxon, PhysicalEssence):
     """
@@ -2625,7 +2729,16 @@ class AnatomicalEntity(OrganismalEntity, ThingWithTaxon, PhysicalEssence):
 
     # Class Variables
     _category: ClassVar[str] = "AnatomicalEntity"
-    _id_prefixes: ClassVar[List[str]] = ["UBERON", "GO", "CL", "UMLS", "MESH", "NCIT"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "UBERON",
+        "GO",
+        "CL",
+        "UMLS",
+        "MESH",
+        "NCIT"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2636,7 +2749,17 @@ class CellularComponent(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "CellularComponent"
-    _id_prefixes: ClassVar[List[str]] = ["GO", "MESH", "UMLS", "NCIT", "SNOMEDCT", "CL", "UBERON"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "GO",
+        "MESH",
+        "UMLS",
+        "NCIT",
+        "SNOMEDCT",
+        "CL",
+        "UBERON"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2644,7 +2767,17 @@ class Cell(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Cell"
-    _id_prefixes: ClassVar[List[str]] = ["CL", "PO", "UMLS", "NCIT", "MESH", "UBERON", "SNOMEDCT"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "CL",
+        "PO",
+        "UMLS",
+        "NCIT",
+        "MESH",
+        "UBERON",
+        "SNOMEDCT"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2652,7 +2785,11 @@ class CellLine(OrganismalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "CellLine"
-    _id_prefixes: ClassVar[List[str]] = ["CLO"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "CLO"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2660,7 +2797,16 @@ class GrossAnatomicalStructure(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "GrossAnatomicalStructure"
-    _id_prefixes: ClassVar[List[str]] = ["UBERON", "UMLS", "MESH", "NCIT", "PO", "FAO"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "UBERON",
+        "UMLS",
+        "MESH",
+        "NCIT",
+        "PO",
+        "FAO"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2670,6 +2816,8 @@ class ChemicalEntityOrGeneOrGeneProduct:
     across chemical entities that must include genes and their children as chemical entities.
     """
 
+    pass
+
 
 @dataclass(config=PydanticConfig)
 class ChemicalEntityOrProteinOrPolypeptide:
@@ -2678,27 +2826,26 @@ class ChemicalEntityOrProteinOrPolypeptide:
     searching across chemical entities that must include genes and their children as chemical entities.
     """
 
+    pass
+
 
 @dataclass(config=PydanticConfig)
-class ChemicalEntity(
-    NamedThing,
-    PhysicalEssence,
-    ChemicalOrDrugOrTreatment,
-    ChemicalEntityOrGeneOrGeneProduct,
-    ChemicalEntityOrProteinOrPolypeptide,
-):
+class ChemicalEntity(NamedThing, PhysicalEssence, ChemicalOrDrugOrTreatment, ChemicalEntityOrGeneOrGeneProduct, ChemicalEntityOrProteinOrPolypeptide):
     """
     A chemical entity is a physical entity that pertains to chemistry or biochemistry.
     """
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalEntity"
-    _id_prefixes: ClassVar[List[str]] = ["UNII", "MESH", "CAS"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "UNII",
+        "MESH",
+        "CAS",
+        "UMLS"
+    ]
 
     trade_name: Optional[Union[URIorCURIE, ChemicalEntity]] = None
-    available_from: Optional[
-        Union[List[Union[str, DrugAvailabilityEnum]], Union[str, DrugAvailabilityEnum]]
-    ] = field(default_factory=list)
+    available_from: Optional[Union[List[Union[str, DrugAvailabilityEnum]], Union[str, DrugAvailabilityEnum]]] = field(default_factory=list)
     max_tolerated_dose: Optional[Union[str, str]] = None
     is_toxic: Optional[Union[bool, Bool]] = None
 
@@ -2744,9 +2891,11 @@ class MolecularEntity(ChemicalEntity):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
+        "UMLS"
     ]
 
     is_metabolite: Optional[Union[bool, Bool]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2783,6 +2932,7 @@ class SmallMolecule(MolecularEntity):
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
         "BIGG.METABOLITE",
+        "UMLS"
     ]
 
     id: URIorCURIE = None
@@ -2826,10 +2976,12 @@ class ChemicalMixture(ChemicalEntity):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
+        "UMLS"
     ]
 
     is_supplement: Optional[Union[URIorCURIE, ChemicalMixture]] = None
     highest_FDA_approval_status: Optional[Union[str, str]] = None
+    drug_regulatory_status_world_wide: Optional[Union[str, str]] = None
 
     # Validators
 
@@ -2854,24 +3006,21 @@ class NucleicAcidEntity(MolecularEntity, GenomicEntity, PhysicalEssence, Ontolog
         "CHEMBL.COMPOUND",
         "UNII",
         "CHEBI",
-        "DRUGBANK",
         "MESH",
         "CAS",
-        "DrugCentral",
         "GTOPDB",
         "HMDB",
         "KEGG.COMPOUND",
         "ChemBank",
         "Aeolus",
         "PUBCHEM.SUBSTANCE",
-        "SIDER.DRUG",
         "INCHI",
         "INCHIKEY",
         "KEGG.GLYCAN",
-        "KEGG.DRUG",
-        "KEGG.DGROUP",
-        "KEGG.ENVIRON",
+        "KEGG.ENVIRON"
     ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2905,7 +3054,10 @@ class MolecularMixture(ChemicalMixture):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
+        "UMLS"
     ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2939,7 +3091,10 @@ class ComplexMolecularMixture(ChemicalMixture):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
+        "UMLS"
     ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2951,6 +3106,11 @@ class ProcessedMaterial(ChemicalMixture):
 
     # Class Variables
     _category: ClassVar[str] = "ProcessedMaterial"
+    _id_prefixes: ClassVar[List[str]] = [
+        "UMLS"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2964,13 +3124,10 @@ class Drug(MolecularMixture, ChemicalOrDrugOrTreatment, OntologyClass):
     _id_prefixes: ClassVar[List[str]] = [
         "RXCUI",
         "NDC",
-        "PHARMGKB.DRUG",
-        "DRUGBANK",
-        "DrugCentral",
-        "KEGG.DRUG",
-        "KEGG.DGROUP",
-        "SIDER.DRUG",
+        "UMLS"
     ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2980,11 +3137,15 @@ class EnvironmentalFoodContaminant(ChemicalEntity):
     _category: ClassVar[str] = "EnvironmentalFoodContaminant"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class FoodAdditive(ChemicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "FoodAdditive"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -2994,11 +3155,15 @@ class Nutrient(ChemicalEntity):
     _category: ClassVar[str] = "Nutrient"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Macronutrient(Nutrient):
 
     # Class Variables
     _category: ClassVar[str] = "Macronutrient"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3008,11 +3173,15 @@ class Micronutrient(Nutrient):
     _category: ClassVar[str] = "Micronutrient"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Vitamin(Micronutrient):
 
     # Class Variables
     _category: ClassVar[str] = "Vitamin"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3023,7 +3192,11 @@ class Food(ChemicalMixture):
 
     # Class Variables
     _category: ClassVar[str] = "Food"
-    _id_prefixes: ClassVar[List[str]] = ["foodb.compound"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "foodb.compound"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3032,8 +3205,8 @@ class MacromolecularMachineMixin:
     A union of gene locus, gene product, and macromolecular complex mixin. These are the basic units of function in a
     cell. They either carry out individual biological activities, or they encode molecules which do this.
     """
-
     name: Optional[Union[str, SymbolType]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3043,18 +3216,16 @@ class GeneOrGeneProduct(MacromolecularMachineMixin):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = ["CHEMBL.TARGET", "IUPHAR.FAMILY"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "CHEMBL.TARGET",
+        "IUPHAR.FAMILY"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
-class Gene(
-    BiologicalEntity,
-    GeneOrGeneProduct,
-    GenomicEntity,
-    ChemicalEntityOrGeneOrGeneProduct,
-    PhysicalEssence,
-    OntologyClass,
-):
+class Gene(BiologicalEntity, GeneOrGeneProduct, GenomicEntity, ChemicalEntityOrGeneOrGeneProduct, PhysicalEssence, OntologyClass):
     """
     A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A
     gene locus may include regulatory regions, transcribed regions and/or other functional sequence regions.
@@ -3078,13 +3249,11 @@ class Gene(
         "OMIM",
         "KEGG.GENE",
         "UMLS",
-        "Xenbase",
+        "Xenbase"
     ]
 
     symbol: Optional[Union[str, str]] = None
-    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(
-        default_factory=list
-    )
+    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(default_factory=list)
     xref: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
 
     # Validators
@@ -3106,11 +3275,13 @@ class GeneProductMixin(GeneOrGeneProduct):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "gtpo", "PR"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "UniProtKB",
+        "gtpo",
+        "PR"
+    ]
 
-    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(
-        default_factory=list
-    )
+    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(default_factory=list)
     xref: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
 
     # Validators
@@ -3132,6 +3303,8 @@ class GeneProductIsoformMixin(GeneProductMixin):
     designation of canonical or reference may be arbitrary, or it may represent the superclass of all isoforms.
     """
 
+    pass
+
 
 @dataclass(config=PydanticConfig)
 class MacromolecularComplexMixin(MacromolecularMachineMixin):
@@ -3141,7 +3314,14 @@ class MacromolecularComplexMixin(MacromolecularMachineMixin):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = ["INTACT", "GO", "PR", "REACT"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "INTACT",
+        "GO",
+        "PR",
+        "REACT"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3152,6 +3332,8 @@ class Genome(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Genome"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3165,6 +3347,8 @@ class Exon(NucleicAcidEntity):
     _category: ClassVar[str] = "Exon"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Transcript(NucleicAcidEntity):
     """
@@ -3173,7 +3357,12 @@ class Transcript(NucleicAcidEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Transcript"
-    _id_prefixes: ClassVar[List[str]] = ["ENSEMBL", "FB"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "ENSEMBL",
+        "FB"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3183,13 +3372,10 @@ class CodingSequence(NucleicAcidEntity):
     _category: ClassVar[str] = "CodingSequence"
 
 
+
+
 @dataclass(config=PydanticConfig)
-class Polypeptide(
-    BiologicalEntity,
-    ThingWithTaxon,
-    ChemicalEntityOrGeneOrGeneProduct,
-    ChemicalEntityOrProteinOrPolypeptide,
-):
+class Polypeptide(BiologicalEntity, ThingWithTaxon, ChemicalEntityOrGeneOrGeneProduct, ChemicalEntityOrProteinOrPolypeptide):
     """
     A polypeptide is a molecular entity characterized by availability in protein databases of amino-acid-based
     sequence representations of its precise primary structure; for convenience of representation, partial sequences of
@@ -3198,7 +3384,15 @@ class Polypeptide(
 
     # Class Variables
     _category: ClassVar[str] = "Polypeptide"
-    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "PR", "ENSEMBL", "FB", "UMLS"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "UniProtKB",
+        "PR",
+        "ENSEMBL",
+        "FB",
+        "UMLS"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3210,7 +3404,16 @@ class Protein(Polypeptide, GeneProductMixin, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "Protein"
-    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "PR", "ENSEMBL", "FB", "UMLS", "MESH"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "UniProtKB",
+        "PR",
+        "ENSEMBL",
+        "FB",
+        "UMLS",
+        "MESH"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3222,7 +3425,14 @@ class ProteinIsoform(Protein, GeneProductIsoformMixin):
 
     # Class Variables
     _category: ClassVar[str] = "ProteinIsoform"
-    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "UNIPROT.ISOFORM", "PR", "ENSEMBL"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "UniProtKB",
+        "UNIPROT.ISOFORM",
+        "PR",
+        "ENSEMBL"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3230,7 +3440,11 @@ class RNAProduct(Transcript, GeneProductMixin):
 
     # Class Variables
     _category: ClassVar[str] = "RNAProduct"
-    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "RNACENTRAL"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3241,7 +3455,11 @@ class RNAProductIsoform(RNAProduct, GeneProductIsoformMixin):
 
     # Class Variables
     _category: ClassVar[str] = "RNAProductIsoform"
-    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "RNACENTRAL"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3249,7 +3467,13 @@ class NoncodingRNAProduct(RNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "NoncodingRNAProduct"
-    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL", "NCBIGene", "ENSEMBL"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "RNACENTRAL",
+        "NCBIGene",
+        "ENSEMBL"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3257,7 +3481,13 @@ class MicroRNA(NoncodingRNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "MicroRNA"
-    _id_prefixes: ClassVar[List[str]] = ["MIR", "HGNC", "WormBase"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "MIR",
+        "HGNC",
+        "WormBase"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3270,7 +3500,13 @@ class SiRNA(NoncodingRNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "SiRNA"
-    _id_prefixes: ClassVar[List[str]] = ["MIR", "HGNC", "WormBase"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "MIR",
+        "HGNC",
+        "WormBase"
+    ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3278,10 +3514,7 @@ class GeneGroupingMixin:
     """
     any grouping of multiple genes or gene products
     """
-
-    has_gene_or_gene_product: Optional[
-        Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]
-    ] = field(default_factory=list)
+    has_gene_or_gene_product: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(default_factory=list)
 
     # Validators
 
@@ -3318,8 +3551,10 @@ class GeneFamily(BiologicalEntity, GeneGroupingMixin, ChemicalEntityOrGeneOrGene
         "RFAM",
         "KEGG.ORTHOLOGY",
         "EGGNOG",
-        "COG",
+        "COG"
     ]
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3327,6 +3562,8 @@ class Zygosity(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "Zygosity"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3338,9 +3575,13 @@ class Genotype(BiologicalEntity, PhysicalEssence, GenomicEntity, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Genotype"
-    _id_prefixes: ClassVar[List[str]] = ["ZFIN", "FB"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "ZFIN",
+        "FB"
+    ]
 
     has_zygosity: Optional[Union[str, Zygosity]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3351,6 +3592,8 @@ class Haplotype(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass)
 
     # Class Variables
     _category: ClassVar[str] = "Haplotype"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3371,13 +3614,11 @@ class SequenceVariant(BiologicalEntity, GenomicEntity, PhysicalEssence, Ontology
         "ZFIN",
         "FB",
         "WB",
-        "WormBase",
+        "WormBase"
     ]
 
     id: URIorCURIE = None
-    has_gene: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(
-        default_factory=list
-    )
+    has_gene: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(default_factory=list)
     has_biological_sequence: Optional[Union[str, BiologicalSequence]] = None
 
     # Validators
@@ -3403,6 +3644,8 @@ class Snv(SequenceVariant):
     _category: ClassVar[str] = "Snv"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class ReagentTargetedGene(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass):
     """
@@ -3414,6 +3657,8 @@ class ReagentTargetedGene(BiologicalEntity, GenomicEntity, PhysicalEssence, Onto
     _category: ClassVar[str] = "ReagentTargetedGene"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class ClinicalAttribute(Attribute):
     """
@@ -3422,6 +3667,8 @@ class ClinicalAttribute(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalAttribute"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3455,6 +3702,8 @@ class ClinicalModifier(ClinicalAttribute):
     _category: ClassVar[str] = "ClinicalModifier"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class ClinicalCourse(ClinicalAttribute):
     """
@@ -3466,6 +3715,8 @@ class ClinicalCourse(ClinicalAttribute):
     _category: ClassVar[str] = "ClinicalCourse"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Onset(ClinicalCourse):
     """
@@ -3474,6 +3725,8 @@ class Onset(ClinicalCourse):
 
     # Class Variables
     _category: ClassVar[str] = "Onset"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3487,6 +3740,8 @@ class ClinicalEntity(NamedThing):
     _category: ClassVar[str] = "ClinicalEntity"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class ClinicalTrial(ClinicalEntity):
 
@@ -3494,11 +3749,15 @@ class ClinicalTrial(ClinicalEntity):
     _category: ClassVar[str] = "ClinicalTrial"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class ClinicalIntervention(ClinicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalIntervention"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3510,11 +3769,13 @@ class ClinicalFinding(PhenotypicFeature):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalFinding"
-    _id_prefixes: ClassVar[List[str]] = ["LOINC", "NCIT", "EFO"]
+    _id_prefixes: ClassVar[List[str]] = [
+        "LOINC",
+        "NCIT",
+        "EFO"
+    ]
 
-    has_attribute: Optional[
-        Union[List[Union[str, ClinicalAttribute]], Union[str, ClinicalAttribute]]
-    ] = field(default_factory=list)
+    has_attribute: Optional[Union[List[Union[str, ClinicalAttribute]], Union[str, ClinicalAttribute]]] = field(default_factory=list)
 
     # Validators
 
@@ -3530,6 +3791,8 @@ class Hospitalization(ClinicalIntervention):
     _category: ClassVar[str] = "Hospitalization"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class SocioeconomicAttribute(Attribute):
     """
@@ -3540,6 +3803,8 @@ class SocioeconomicAttribute(Attribute):
     _category: ClassVar[str] = "SocioeconomicAttribute"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Case(IndividualOrganism):
     """
@@ -3548,6 +3813,8 @@ class Case(IndividualOrganism):
 
     # Class Variables
     _category: ClassVar[str] = "Case"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3561,20 +3828,20 @@ class Cohort(StudyPopulation):
     _category: ClassVar[str] = "Cohort"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class ExposureEvent:
     """
     A (possibly time bounded) incidence of a feature of the environment of an organism that influences one or more
     phenotypic features of that organism, potentially mediated by genes
     """
-
     timepoint: Optional[Union[str, TimeType]] = None
 
 
+
 @dataclass(config=PydanticConfig)
-class GenomicBackgroundExposure(
-    ExposureEvent, GeneGroupingMixin, PhysicalEssence, GenomicEntity, OntologyClass
-):
+class GenomicBackgroundExposure(ExposureEvent, GeneGroupingMixin, PhysicalEssence, GenomicEntity, OntologyClass):
     """
     A genomic background exposure is where an individual's specific genomic background of genes, sequence variants or
     other pre-existing genomic conditions constitute a kind of 'exposure' to the organism, leading to or influencing
@@ -3585,11 +3852,15 @@ class GenomicBackgroundExposure(
     _category: ClassVar[str] = "GenomicBackgroundExposure"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class PathologicalEntityMixin:
     """
     A pathological (abnormal) structure or process.
     """
+
+    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -3603,6 +3874,8 @@ class PathologicalProcess(BiologicalProcess, PathologicalEntityMixin):
     _category: ClassVar[str] = "PathologicalProcess"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class PathologicalProcessExposure(ExposureEvent):
     """
@@ -3612,6 +3885,8 @@ class PathologicalProcessExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalProcessExposure"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3625,6 +3900,8 @@ class PathologicalAnatomicalStructure(AnatomicalEntity, PathologicalEntityMixin)
     _category: ClassVar[str] = "PathologicalAnatomicalStructure"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class PathologicalAnatomicalExposure(ExposureEvent):
     """
@@ -3634,6 +3911,8 @@ class PathologicalAnatomicalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalAnatomicalExposure"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3648,6 +3927,8 @@ class DiseaseOrPhenotypicFeatureExposure(ExposureEvent, PathologicalEntityMixin)
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeatureExposure"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class ChemicalExposure(ExposureEvent):
     """
@@ -3656,6 +3937,8 @@ class ChemicalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalExposure"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3668,6 +3951,8 @@ class ComplexChemicalExposure:
     _category: ClassVar[str] = "ComplexChemicalExposure"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class DrugExposure(ChemicalExposure, ExposureEvent):
     """
@@ -3676,6 +3961,8 @@ class DrugExposure(ChemicalExposure, ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "DrugExposure"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3689,6 +3976,8 @@ class DrugToGeneInteractionExposure(DrugExposure, GeneGroupingMixin):
     _category: ClassVar[str] = "DrugToGeneInteractionExposure"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class Treatment(NamedThing, ExposureEvent, ChemicalOrDrugOrTreatment):
     """
@@ -3699,15 +3988,9 @@ class Treatment(NamedThing, ExposureEvent, ChemicalOrDrugOrTreatment):
     # Class Variables
     _category: ClassVar[str] = "Treatment"
 
-    has_drug: Optional[Union[List[Union[URIorCURIE, Drug]], Union[URIorCURIE, Drug]]] = field(
-        default_factory=list
-    )
-    has_device: Optional[Union[List[Union[URIorCURIE, Device]], Union[URIorCURIE, Device]]] = field(
-        default_factory=list
-    )
-    has_procedure: Optional[
-        Union[List[Union[URIorCURIE, Procedure]], Union[URIorCURIE, Procedure]]
-    ] = field(default_factory=list)
+    has_drug: Optional[Union[List[Union[URIorCURIE, Drug]], Union[URIorCURIE, Drug]]] = field(default_factory=list)
+    has_device: Optional[Union[List[Union[URIorCURIE, Device]], Union[URIorCURIE, Device]]] = field(default_factory=list)
+    has_procedure: Optional[Union[List[Union[URIorCURIE, Procedure]], Union[URIorCURIE, Procedure]]] = field(default_factory=list)
 
     # Validators
 
@@ -3734,6 +4017,8 @@ class BioticExposure(ExposureEvent):
     _category: ClassVar[str] = "BioticExposure"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class EnvironmentalExposure(ExposureEvent):
     """
@@ -3743,6 +4028,8 @@ class EnvironmentalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "EnvironmentalExposure"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3755,6 +4042,8 @@ class GeographicExposure(EnvironmentalExposure, ExposureEvent):
     _category: ClassVar[str] = "GeographicExposure"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class BehavioralExposure(ExposureEvent):
     """
@@ -3763,6 +4052,8 @@ class BehavioralExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "BehavioralExposure"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3775,9 +4066,7 @@ class SocioeconomicExposure(ExposureEvent):
     # Class Variables
     _category: ClassVar[str] = "SocioeconomicExposure"
 
-    has_attribute: Union[
-        List[Union[str, SocioeconomicAttribute]], Union[str, SocioeconomicAttribute]
-    ] = None
+    has_attribute: Union[List[Union[str, SocioeconomicAttribute]], Union[str, SocioeconomicAttribute]] = None
 
     # Validators
 
@@ -3795,6 +4084,8 @@ class Outcome:
     various categories of possible biological or non-biological (e.g. clinical) outcomes.
     """
 
+    pass
+
 
 @dataclass(config=PydanticConfig)
 class PathologicalProcessOutcome(Outcome):
@@ -3806,6 +4097,8 @@ class PathologicalProcessOutcome(Outcome):
     _category: ClassVar[str] = "PathologicalProcessOutcome"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class PathologicalAnatomicalOutcome(Outcome):
     """
@@ -3814,6 +4107,8 @@ class PathologicalAnatomicalOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalAnatomicalOutcome"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3827,6 +4122,8 @@ class DiseaseOrPhenotypicFeatureOutcome(Outcome):
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeatureOutcome"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class BehavioralOutcome(Outcome):
     """
@@ -3835,6 +4132,8 @@ class BehavioralOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "BehavioralOutcome"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3848,6 +4147,8 @@ class HospitalizationOutcome(Outcome):
     _category: ClassVar[str] = "HospitalizationOutcome"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class MortalityOutcome(Outcome):
     """
@@ -3856,6 +4157,8 @@ class MortalityOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "MortalityOutcome"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3868,6 +4171,8 @@ class EpidemiologicalOutcome(Outcome):
     _category: ClassVar[str] = "EpidemiologicalOutcome"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class SocioeconomicOutcome(Outcome):
     """
@@ -3877,6 +4182,8 @@ class SocioeconomicOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "SocioeconomicOutcome"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -3893,15 +4200,9 @@ class Association(Entity):
     object: Union[URIorCURIE, NamedThing] = None
     relation: Optional[Union[str, str]] = None
     negated: Optional[Union[bool, Bool]] = None
-    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(
-        default_factory=list
-    )
-    publications: Optional[
-        Union[List[Union[URIorCURIE, Publication]], Union[URIorCURIE, Publication]]
-    ] = field(default_factory=list)
-    has_evidence: Optional[
-        Union[List[Union[URIorCURIE, EvidenceType]], Union[URIorCURIE, EvidenceType]]
-    ] = field(default_factory=list)
+    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(default_factory=list)
+    publications: Optional[Union[List[Union[URIorCURIE, Publication]], Union[URIorCURIE, Publication]]] = field(default_factory=list)
+    has_evidence: Optional[Union[List[Union[URIorCURIE, EvidenceType]], Union[URIorCURIE, EvidenceType]]] = field(default_factory=list)
     type: Optional[Union[str, str]] = None
     category: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
 
@@ -3953,9 +4254,7 @@ class ContributorAssociation(Association):
     subject: Union[URIorCURIE, InformationContentEntity] = None
     predicate: Union[str, PredicateType] = None
     object: Union[URIorCURIE, Agent] = None
-    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(
-        default_factory=list
-    )
+    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(default_factory=list)
 
     # Validators
 
@@ -4087,7 +4386,6 @@ class GeneToGeneAssociation(Association):
     abstract parent class for different kinds of gene-gene or gene product to gene product relationships. Includes
     homology and interaction.
     """
-
     subject: Union[str, GeneOrGeneProduct] = None
     object: Union[str, GeneOrGeneProduct] = None
 
@@ -4130,7 +4428,6 @@ class GeneExpressionMixin:
     Observed gene expression intensity, context (site, stage) and associated phenotypic status within which the
     expression occurs.
     """
-
     quantifier_qualifier: Optional[Union[str, OntologyClass]] = None
     expression_site: Optional[Union[URIorCURIE, AnatomicalEntity]] = None
     stage_qualifier: Optional[Union[URIorCURIE, LifeStage]] = None
@@ -4241,7 +4538,6 @@ class CellLineToEntityAssociationMixin:
     """
     An relationship between a cell line and another entity
     """
-
     subject: Union[URIorCURIE, CellLine] = None
 
     # Validators
@@ -4258,15 +4554,13 @@ class ChemicalEntityToEntityAssociationMixin:
     """
     An interaction between a chemical entity and another entity
     """
-
-    subject: Union[URIorCURIE, ChemicalEntity] = None
+    subject: Union[str, ChemicalEntityOrGeneOrGeneProduct] = None
 
     # Validators
 
     @validator('subject', allow_reuse=True)
     def validate_required_subject(cls, value):
         check_value_is_not_none("subject", value)
-        check_curie_prefix(ChemicalEntity, value)
         return value
 
 
@@ -4275,7 +4569,6 @@ class DrugToEntityAssociationMixin(ChemicalEntityToEntityAssociationMixin):
     """
     An interaction between a drug and another entity
     """
-
     subject: Union[URIorCURIE, Drug] = None
 
     # Validators
@@ -4292,15 +4585,13 @@ class ChemicalToEntityAssociationMixin(ChemicalEntityToEntityAssociationMixin):
     """
     An interaction between a chemical entity and another entity
     """
-
-    subject: Union[URIorCURIE, ChemicalEntity] = None
+    subject: Union[str, ChemicalEntityOrGeneOrGeneProduct] = None
 
     # Validators
 
     @validator('subject', allow_reuse=True)
     def validate_required_subject(cls, value):
         check_value_is_not_none("subject", value)
-        check_curie_prefix(ChemicalEntity, value)
         return value
 
 
@@ -4309,7 +4600,6 @@ class CaseToEntityAssociationMixin:
     """
     An abstract association for use where the case is the subject
     """
-
     subject: Union[URIorCURIE, Case] = None
 
     # Validators
@@ -4398,9 +4688,7 @@ class ChemicalToChemicalDerivationAssociation(ChemicalToChemicalAssociation):
     subject: Union[URIorCURIE, ChemicalEntity] = None
     object: Union[URIorCURIE, ChemicalEntity] = None
     predicate: Union[str, PredicateType] = None
-    catalyst_qualifier: Optional[
-        Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]
-    ] = field(default_factory=list)
+    catalyst_qualifier: Optional[Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]] = field(default_factory=list)
 
     # Validators
 
@@ -4489,7 +4777,6 @@ class MaterialSampleToEntityAssociationMixin:
     """
     An association between a material sample and something.
     """
-
     subject: Union[URIorCURIE, MaterialSample] = None
 
     # Validators
@@ -4552,7 +4839,6 @@ class EntityToExposureEventAssociationMixin:
     """
     An association between some entity and an exposure event.
     """
-
     object: Union[str, ExposureEvent] = None
 
     # Validators
@@ -4564,15 +4850,15 @@ class EntityToExposureEventAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseToExposureEventAssociation(
-    Association, DiseaseToEntityAssociationMixin, EntityToExposureEventAssociationMixin
-):
+class DiseaseToExposureEventAssociation(Association, DiseaseToEntityAssociationMixin, EntityToExposureEventAssociationMixin):
     """
     An association between an exposure event and a disease.
     """
 
     # Class Variables
     _category: ClassVar[str] = "DiseaseToExposureEventAssociation"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -4582,12 +4868,13 @@ class ExposureEventToEntityAssociationMixin:
     _category: ClassVar[str] = "ExposureEventToEntityAssociationMixin"
 
 
+
+
 @dataclass(config=PydanticConfig)
 class EntityToOutcomeAssociationMixin:
     """
     An association between some entity and an outcome
     """
-
     object: Union[str, Outcome] = None
 
     # Validators
@@ -4599,9 +4886,7 @@ class EntityToOutcomeAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class ExposureEventToOutcomeAssociation(
-    Association, ExposureEventToEntityAssociationMixin, EntityToOutcomeAssociationMixin
-):
+class ExposureEventToOutcomeAssociation(Association, ExposureEventToEntityAssociationMixin, EntityToOutcomeAssociationMixin):
     """
     An association between an exposure event and an outcome.
     """
@@ -4625,8 +4910,8 @@ class FrequencyQualifierMixin:
     """
     Qualifier for frequency type associations
     """
-
     frequency_qualifier: Optional[Union[str, FrequencyValue]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -4634,9 +4919,9 @@ class EntityToFeatureOrDiseaseQualifiersMixin(FrequencyQualifierMixin):
     """
     Qualifiers for entity to disease or phenotype associations.
     """
-
     severity_qualifier: Optional[Union[str, SeverityValue]] = None
     onset_qualifier: Optional[Union[str, Onset]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -4697,7 +4982,6 @@ class EntityToDiseaseAssociationMixin(EntityToFeatureOrDiseaseQualifiersMixin):
     """
     mixin class for any association whose object (target node) is a disease
     """
-
     object: Union[URIorCURIE, Disease] = None
 
     # Validators
@@ -4723,9 +5007,7 @@ class DiseaseOrPhenotypicFeatureToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseOrPhenotypicFeatureToLocationAssociation(
-    Association, DiseaseOrPhenotypicFeatureToEntityAssociationMixin
-):
+class DiseaseOrPhenotypicFeatureToLocationAssociation(Association, DiseaseOrPhenotypicFeatureToEntityAssociationMixin):
     """
     An association between either a disease or a phenotypic feature and an anatomical entity, where the
     disease/feature manifests in that site.
@@ -4759,11 +5041,7 @@ class EntityToDiseaseOrPhenotypicFeatureAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class CellLineToDiseaseOrPhenotypicFeatureAssociation(
-    Association,
-    CellLineToEntityAssociationMixin,
-    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
-):
+class CellLineToDiseaseOrPhenotypicFeatureAssociation(Association, CellLineToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
     """
     An relationship between a cell line and a disease or a phenotype, where the cell line is derived from an
     individual with that disease or phenotype.
@@ -4784,11 +5062,7 @@ class CellLineToDiseaseOrPhenotypicFeatureAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class ChemicalToDiseaseOrPhenotypicFeatureAssociation(
-    Association,
-    ChemicalToEntityAssociationMixin,
-    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
-):
+class ChemicalToDiseaseOrPhenotypicFeatureAssociation(Association, ChemicalToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
     """
     An interaction between a chemical entity and a phenotype or disease, where the presence of the chemical gives rise
     to or exacerbates the phenotype.
@@ -4809,17 +5083,15 @@ class ChemicalToDiseaseOrPhenotypicFeatureAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class MaterialSampleToDiseaseOrPhenotypicFeatureAssociation(
-    Association,
-    MaterialSampleToEntityAssociationMixin,
-    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
-):
+class MaterialSampleToDiseaseOrPhenotypicFeatureAssociation(Association, MaterialSampleToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
     """
     An association between a material sample and a disease or phenotype.
     """
 
     # Class Variables
     _category: ClassVar[str] = "MaterialSampleToDiseaseOrPhenotypicFeatureAssociation"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -4836,9 +5108,7 @@ class GenotypeToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeToPhenotypicFeatureAssociation(
-    Association, EntityToPhenotypicFeatureAssociationMixin, GenotypeToEntityAssociationMixin
-):
+class GenotypeToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, GenotypeToEntityAssociationMixin):
     """
     Any association between one genotype and a phenotypic feature, where having the genotype confers the phenotype,
     either in isolation or through environment
@@ -4865,9 +5135,7 @@ class GenotypeToPhenotypicFeatureAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class ExposureEventToPhenotypicFeatureAssociation(
-    Association, EntityToPhenotypicFeatureAssociationMixin
-):
+class ExposureEventToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin):
     """
     Any association between an environment and a phenotypic feature, where being in the environment influences the
     phenotype.
@@ -4887,9 +5155,7 @@ class ExposureEventToPhenotypicFeatureAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseToPhenotypicFeatureAssociation(
-    Association, EntityToPhenotypicFeatureAssociationMixin, DiseaseToEntityAssociationMixin
-):
+class DiseaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, DiseaseToEntityAssociationMixin):
     """
     An association between a disease and a phenotypic feature in which the phenotypic feature is associated with the
     disease in some way.
@@ -4899,10 +5165,10 @@ class DiseaseToPhenotypicFeatureAssociation(
     _category: ClassVar[str] = "DiseaseToPhenotypicFeatureAssociation"
 
 
+
+
 @dataclass(config=PydanticConfig)
-class CaseToPhenotypicFeatureAssociation(
-    Association, EntityToPhenotypicFeatureAssociationMixin, CaseToEntityAssociationMixin
-):
+class CaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, CaseToEntityAssociationMixin):
     """
     An association between a case (e.g. individual patient) and a phenotypic feature in which the individual has or
     has had the phenotype.
@@ -4912,10 +5178,10 @@ class CaseToPhenotypicFeatureAssociation(
     _category: ClassVar[str] = "CaseToPhenotypicFeatureAssociation"
 
 
+
+
 @dataclass(config=PydanticConfig)
-class BehaviorToBehavioralFeatureAssociation(
-    Association, EntityToPhenotypicFeatureAssociationMixin
-):
+class BehaviorToBehavioralFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin):
     """
     An association between an mixture behavior and a behavioral feature manifested by the individual exhibited or has
     exhibited the behavior.
@@ -4968,9 +5234,7 @@ class VariantToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GeneToPhenotypicFeatureAssociation(
-    Association, EntityToPhenotypicFeatureAssociationMixin, GeneToEntityAssociationMixin
-):
+class GeneToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, GeneToEntityAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "GeneToPhenotypicFeatureAssociation"
@@ -4986,9 +5250,7 @@ class GeneToPhenotypicFeatureAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class GeneToDiseaseAssociation(
-    Association, EntityToDiseaseAssociationMixin, GeneToEntityAssociationMixin
-):
+class GeneToDiseaseAssociation(Association, EntityToDiseaseAssociationMixin, GeneToEntityAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "GeneToDiseaseAssociation"
@@ -5050,9 +5312,7 @@ class VariantToGeneExpressionAssociation(VariantToGeneAssociation, GeneExpressio
 
 
 @dataclass(config=PydanticConfig)
-class VariantToPopulationAssociation(
-    Association, VariantToEntityAssociationMixin, FrequencyQuantifier, FrequencyQualifierMixin
-):
+class VariantToPopulationAssociation(Association, VariantToEntityAssociationMixin, FrequencyQuantifier, FrequencyQualifierMixin):
     """
     An association between a variant and a population, where the variant has particular frequency in the population
     """
@@ -5115,9 +5375,7 @@ class PopulationToPopulationAssociation(Association):
 
 
 @dataclass(config=PydanticConfig)
-class VariantToPhenotypicFeatureAssociation(
-    Association, VariantToEntityAssociationMixin, EntityToPhenotypicFeatureAssociationMixin
-):
+class VariantToPhenotypicFeatureAssociation(Association, VariantToEntityAssociationMixin, EntityToPhenotypicFeatureAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "VariantToPhenotypicFeatureAssociation"
@@ -5134,9 +5392,7 @@ class VariantToPhenotypicFeatureAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class VariantToDiseaseAssociation(
-    Association, VariantToEntityAssociationMixin, EntityToDiseaseAssociationMixin
-):
+class VariantToDiseaseAssociation(Association, VariantToEntityAssociationMixin, EntityToDiseaseAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "VariantToDiseaseAssociation"
@@ -5166,9 +5422,7 @@ class VariantToDiseaseAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeToDiseaseAssociation(
-    Association, GenotypeToEntityAssociationMixin, EntityToDiseaseAssociationMixin
-):
+class GenotypeToDiseaseAssociation(Association, GenotypeToEntityAssociationMixin, EntityToDiseaseAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "GenotypeToDiseaseAssociation"
@@ -5204,7 +5458,6 @@ class ModelToDiseaseAssociationMixin:
     that it recapitulates some features of the disease in a way that is useful for studying the disease outside a
     patient carrying the disease
     """
-
     subject: Union[URIorCURIE, NamedThing] = None
     predicate: Union[str, PredicateType] = None
 
@@ -5223,9 +5476,7 @@ class ModelToDiseaseAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GeneAsAModelOfDiseaseAssociation(
-    GeneToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
-):
+class GeneAsAModelOfDiseaseAssociation(GeneToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "GeneAsAModelOfDiseaseAssociation"
@@ -5241,9 +5492,7 @@ class GeneAsAModelOfDiseaseAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class VariantAsAModelOfDiseaseAssociation(
-    VariantToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
-):
+class VariantAsAModelOfDiseaseAssociation(VariantToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "VariantAsAModelOfDiseaseAssociation"
@@ -5260,9 +5509,7 @@ class VariantAsAModelOfDiseaseAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeAsAModelOfDiseaseAssociation(
-    GenotypeToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
-):
+class GenotypeAsAModelOfDiseaseAssociation(GenotypeToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "GenotypeAsAModelOfDiseaseAssociation"
@@ -5279,11 +5526,7 @@ class GenotypeAsAModelOfDiseaseAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class CellLineAsAModelOfDiseaseAssociation(
-    CellLineToDiseaseOrPhenotypicFeatureAssociation,
-    ModelToDiseaseAssociationMixin,
-    EntityToDiseaseAssociationMixin,
-):
+class CellLineAsAModelOfDiseaseAssociation(CellLineToDiseaseOrPhenotypicFeatureAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "CellLineAsAModelOfDiseaseAssociation"
@@ -5300,9 +5543,7 @@ class CellLineAsAModelOfDiseaseAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class OrganismalEntityAsAModelOfDiseaseAssociation(
-    Association, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
-):
+class OrganismalEntityAsAModelOfDiseaseAssociation(Association, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
 
     # Class Variables
     _category: ClassVar[str] = "OrganismalEntityAsAModelOfDiseaseAssociation"
@@ -5435,7 +5676,6 @@ class SequenceVariantModulatesTreatmentAssociation(Association):
     An association between a sequence variant and a treatment or health intervention. The treatment object itself
     encompasses both the disease and the drug used.
     """
-
     subject: Union[URIorCURIE, SequenceVariant] = None
     object: Union[URIorCURIE, Treatment] = None
 
@@ -5485,7 +5725,6 @@ class MacromolecularMachineToEntityAssociationMixin:
     """
     an association which has a macromolecular machine mixin as a subject
     """
-
     subject: Union[URIorCURIE, NamedThing] = None
 
     # Validators
@@ -5498,9 +5737,7 @@ class MacromolecularMachineToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToMolecularActivityAssociation(
-    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
-):
+class MacromolecularMachineToMolecularActivityAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a molecular activity
     (as represented in the GO molecular function branch), where the entity carries out the activity, or contributes to
@@ -5522,9 +5759,7 @@ class MacromolecularMachineToMolecularActivityAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToBiologicalProcessAssociation(
-    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
-):
+class MacromolecularMachineToBiologicalProcessAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a biological process
     or pathway (as represented in the GO biological process branch), where the entity carries out some part of the
@@ -5546,9 +5781,7 @@ class MacromolecularMachineToBiologicalProcessAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToCellularComponentAssociation(
-    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
-):
+class MacromolecularMachineToCellularComponentAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a cellular component
     (as represented in the GO cellular component branch), where the entity carries out its function in the cellular
@@ -5566,6 +5799,62 @@ class MacromolecularMachineToCellularComponentAssociation(
     def validate_required_object(cls, value):
         check_value_is_not_none("object", value)
         check_curie_prefix(CellularComponent, value)
+        return value
+
+
+@dataclass(config=PydanticConfig)
+class MolecularActivityToChemicalEntityAssociation(Association):
+    """
+    Added in response to capturing relationship between microbiome activities as measured via measurements of blood
+    analytes as collected via blood and stool samples
+    """
+
+    # Class Variables
+    _category: ClassVar[str] = "MolecularActivityToChemicalEntityAssociation"
+
+    subject: Union[URIorCURIE, MolecularActivity] = None
+    object: Union[URIorCURIE, ChemicalEntity] = None
+
+    # Validators
+
+    @validator('subject', allow_reuse=True)
+    def validate_required_subject(cls, value):
+        check_value_is_not_none("subject", value)
+        check_curie_prefix(MolecularActivity, value)
+        return value
+
+    @validator('object', allow_reuse=True)
+    def validate_required_object(cls, value):
+        check_value_is_not_none("object", value)
+        check_curie_prefix(ChemicalEntity, value)
+        return value
+
+
+@dataclass(config=PydanticConfig)
+class MolecularActivityToMolecularActivityAssociation(Association):
+    """
+    Added in response to capturing relationship between microbiome activities as measured via measurements of blood
+    analytes as collected via blood and stool samples
+    """
+
+    # Class Variables
+    _category: ClassVar[str] = "MolecularActivityToMolecularActivityAssociation"
+
+    subject: Union[URIorCURIE, MolecularActivity] = None
+    object: Union[URIorCURIE, MolecularActivity] = None
+
+    # Validators
+
+    @validator('subject', allow_reuse=True)
+    def validate_required_subject(cls, value):
+        check_value_is_not_none("subject", value)
+        check_curie_prefix(MolecularActivity, value)
+        return value
+
+    @validator('object', allow_reuse=True)
+    def validate_required_object(cls, value):
+        check_value_is_not_none("object", value)
+        check_curie_prefix(MolecularActivity, value)
         return value
 
 
@@ -5601,6 +5890,7 @@ class EntityToDiseaseAssociation(Association):
     FDA_approval_status: Optional[Union[str, FDAApprovalStatusEnum]] = None
 
 
+
 @dataclass(config=PydanticConfig)
 class EntityToPhenotypicFeatureAssociation(Association):
 
@@ -5608,6 +5898,7 @@ class EntityToPhenotypicFeatureAssociation(Association):
     _category: ClassVar[str] = "EntityToPhenotypicFeatureAssociation"
 
     FDA_approval_status: Optional[Union[str, FDAApprovalStatusEnum]] = None
+
 
 
 @dataclass(config=PydanticConfig)
@@ -5618,6 +5909,8 @@ class SequenceAssociation(Association):
 
     # Class Variables
     _category: ClassVar[str] = "SequenceAssociation"
+
+
 
 
 @dataclass(config=PydanticConfig)
@@ -5824,9 +6117,7 @@ class AnatomicalEntityToAnatomicalEntityAssociation(Association):
 
 
 @dataclass(config=PydanticConfig)
-class AnatomicalEntityToAnatomicalEntityPartOfAssociation(
-    AnatomicalEntityToAnatomicalEntityAssociation
-):
+class AnatomicalEntityToAnatomicalEntityPartOfAssociation(AnatomicalEntityToAnatomicalEntityAssociation):
     """
     A relationship between two anatomical entities where the relationship is mereological, i.e the two entities are
     related by parthood. This includes relationships between cellular components and cells, between cells and tissues,
@@ -5861,9 +6152,7 @@ class AnatomicalEntityToAnatomicalEntityPartOfAssociation(
 
 
 @dataclass(config=PydanticConfig)
-class AnatomicalEntityToAnatomicalEntityOntogenicAssociation(
-    AnatomicalEntityToAnatomicalEntityAssociation
-):
+class AnatomicalEntityToAnatomicalEntityOntogenicAssociation(AnatomicalEntityToAnatomicalEntityAssociation):
     """
     A relationship between two anatomical entities where the relationship is ontogenic, i.e. the two entities are
     related by development. A number of different relationship types can be used to specify the precise nature of the
@@ -5902,7 +6191,6 @@ class OrganismTaxonToEntityAssociation:
     """
     An association between an organism taxon and another entity
     """
-
     subject: Union[URIorCURIE, OrganismTaxon] = None
 
     # Validators
@@ -5919,7 +6207,6 @@ class OrganismTaxonToOrganismTaxonAssociation(Association, OrganismTaxonToEntity
     """
     A relationship between two organism taxon nodes
     """
-
     subject: Union[URIorCURIE, OrganismTaxon] = None
     object: Union[URIorCURIE, OrganismTaxon] = None
 
@@ -6274,6 +6561,8 @@ MacromolecularMachineToEntityAssociationMixin.__pydantic_model__.update_forward_
 MacromolecularMachineToMolecularActivityAssociation.__pydantic_model__.update_forward_refs()
 MacromolecularMachineToBiologicalProcessAssociation.__pydantic_model__.update_forward_refs()
 MacromolecularMachineToCellularComponentAssociation.__pydantic_model__.update_forward_refs()
+MolecularActivityToChemicalEntityAssociation.__pydantic_model__.update_forward_refs()
+MolecularActivityToMolecularActivityAssociation.__pydantic_model__.update_forward_refs()
 GeneToGoTermAssociation.__pydantic_model__.update_forward_refs()
 EntityToDiseaseAssociation.__pydantic_model__.update_forward_refs()
 EntityToPhenotypicFeatureAssociation.__pydantic_model__.update_forward_refs()
@@ -6292,3 +6581,5 @@ OrganismTaxonToOrganismTaxonAssociation.__pydantic_model__.update_forward_refs()
 OrganismTaxonToOrganismTaxonSpecialization.__pydantic_model__.update_forward_refs()
 OrganismTaxonToOrganismTaxonInteraction.__pydantic_model__.update_forward_refs()
 OrganismTaxonToEnvironmentAssociation.__pydantic_model__.update_forward_refs()
+
+

--- a/pydanticgen/pydanticgen.py
+++ b/pydanticgen/pydanticgen.py
@@ -568,7 +568,7 @@ class {enum_name}(str, Enum):
             if 'related to' in self.ancestors(slot):
                 predicates.append(slot.name)
 
-        predicates = [pred.replace(' ', '_') for pred in sorted(predicates)]
+        predicates = [pred.replace(' ', '_').replace('-', '_') for pred in sorted(predicates)]
         formatted_predicates = '\n'.join([f'    {pred} = "biolink:{pred}"' for pred in predicates])
 
         return f'''


### PR DESCRIPTION
plus replacing dashes with underscores for predicates

The dash in co-occurs could end up getting changed upstream, but it seems like a reasonable bit of defensiveness to include it here anyway. 