### PR TITLE
Performance improvements, options for excluding validators/converters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # Builds and runs pytest on ubuntu-latest
 # Tests python versions >=3.6
-name: CI
+name: test
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,5 @@ biolink-model.yaml: FORCE
 	$(WGET) https://raw.githubusercontent.com/biolink/biolink-model/master/biolink-model.yaml
 
 biolink_model_pydantic/model.py: install-dev biolink-model.yaml
-	pydanticgen/pydanticgen.py biolink-model.yaml > biolink_model_pydantic/model.py
+	pydanticgen/pydanticgen.py biolink-model.yaml \
+	    --skip-field-validator category > biolink_model_pydantic/model.py

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Pyversions](https://img.shields.io/pypi/pyversions/biolink_model_pydantic.svg)](https://pypi.python.org/pypi/biolink_model_pydantic)
+![](https://github.com/monarch-initiative/biolink-model-pydantic/actions/workflows/test.yml/badge.svg)
+[![PyPi](https://img.shields.io/pypi/v/biolink_model_pydantic.svg)](https://pypi.python.org/pypi/biolink_model_pydantic)
+
 # biolink-model-pydantic
 Pydantic dataclasses for the Biolink model
 

--- a/biolink_model_pydantic/__init__.py
+++ b/biolink_model_pydantic/__init__.py
@@ -1,2 +1,2 @@
 """Pydantic dataclasses for the Biolink model"""
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/biolink_model_pydantic/model.py
+++ b/biolink_model_pydantic/model.py
@@ -1,5 +1,5 @@
 # Auto generated from biolink-model.yaml by pydanticgen.py version: 0.9.0
-# Generation date: 2021-10-25 12:16
+# Generation date: 2021-11-04 12:34
 # Schema: Biolink-Model
 #
 # id: https://w3id.org/biolink/biolink-model
@@ -32,6 +32,7 @@ LabelType = str
 IriType = constr(regex=r'^(http|ftp)')
 Curie = constr(regex=curie_regexp)
 URIorCURIE = Union[Curie, IriType]
+CategoryType = URIorCURIE
 NarrativeText = str
 XSDDate = datetime.date
 TimeType = datetime.time
@@ -44,7 +45,7 @@ Bool = bool
 
 # Namespaces
 
-valid_prefix = [
+valid_prefix = {
     "AAO",
     "ABS",
     "ACEVIEW_WORM",
@@ -1057,11 +1058,11 @@ valid_prefix = [
     "void",
     "wgs",
     "xml",
-    "xsd"
-]
+    "xsd",
+}
 
 
-# Pydantic config and validators
+# Pydantic Config
 class PydanticConfig:
     """
     Pydantic config
@@ -1075,6 +1076,7 @@ class PydanticConfig:
     arbitrary_types_allowed = True  # TODO re-evaluate this
 
 
+# Pydantic Validators
 def check_curie_prefix(cls, curie: Union[List, str, None]):
     if isinstance(curie, list):
         for cur in curie:
@@ -1090,7 +1092,7 @@ def check_curie_prefix(cls, curie: Union[List, str, None]):
                         f"for a list of valid curie prefixes"
                     )
     elif curie:
-        prefix = curie.split(':')[0]
+        prefix, local_id = curie.split(':')
         if prefix not in valid_prefix:
             LOG.warning(f"{curie} prefix '{prefix}' not in curie map")
             if hasattr(cls, '_id_prefixes') and cls._id_prefixes:
@@ -1100,6 +1102,8 @@ def check_curie_prefix(cls, curie: Union[List, str, None]):
                     f"See https://biolink.github.io/biolink-model/context.jsonld "
                     f"for a list of valid curie prefixes"
                 )
+        if local_id == '':
+            LOG.warning(f"{curie} does not have a local identifier")
 
 
 def convert_scalar_to_list_check_curies(cls, value: Any) -> List[str]:
@@ -1150,8 +1154,12 @@ class PredicateType(str, Enum):
     acts_upstream_of = "biolink:acts_upstream_of"
     acts_upstream_of_negative_effect = "biolink:acts_upstream_of_negative_effect"
     acts_upstream_of_or_within = "biolink:acts_upstream_of_or_within"
-    acts_upstream_of_or_within_negative_effect = "biolink:acts_upstream_of_or_within_negative_effect"
-    acts_upstream_of_or_within_positive_effect = "biolink:acts_upstream_of_or_within_positive_effect"
+    acts_upstream_of_or_within_negative_effect = (
+        "biolink:acts_upstream_of_or_within_negative_effect"
+    )
+    acts_upstream_of_or_within_positive_effect = (
+        "biolink:acts_upstream_of_or_within_positive_effect"
+    )
     acts_upstream_of_positive_effect = "biolink:acts_upstream_of_positive_effect"
     adverse_event_caused_by = "biolink:adverse_event_caused_by"
     affected_by = "biolink:affected_by"
@@ -1286,7 +1294,9 @@ class PredicateType(str, Enum):
     has_phenotype = "biolink:has_phenotype"
     has_positive_upstream_actor = "biolink:has_positive_upstream_actor"
     has_positive_upstream_or_within_actor = "biolink:has_positive_upstream_or_within_actor"
-    has_real_world_evidence_of_association_with = "biolink:has_real_world_evidence_of_association_with"
+    has_real_world_evidence_of_association_with = (
+        "biolink:has_real_world_evidence_of_association_with"
+    )
     has_sequence_location = "biolink:has_sequence_location"
     has_sequence_variant = "biolink:has_sequence_variant"
     has_splice_site_variant = "biolink:has_splice_site_variant"
@@ -1434,6 +1444,7 @@ class PredicateType(str, Enum):
     variant_part_of = "biolink:variant_part_of"
     xenologous_to = "biolink:xenologous_to"
 
+
 Predicate = namedtuple(
     'biolink_predicate', [pred.value.replace('biolink:', '') for pred in PredicateType]
 )(*[pred.value for pred in PredicateType])
@@ -1447,6 +1458,7 @@ class LogicalInterpretationEnum(str, Enum):
     AllSome = "AllSome"
     InverseAllSome = "InverseAllSome"
 
+
 @unique
 class ReactionDirectionEnum(str, Enum):
 
@@ -1455,38 +1467,46 @@ class ReactionDirectionEnum(str, Enum):
     bidirectional = "bidirectional"
     neutral = "neutral"
 
+
 @unique
 class ReactionSideEnum(str, Enum):
 
     left = "left"
     right = "right"
 
+
 @unique
 class PhaseEnum(str, Enum):
     """
     phase
     """
+
     value_0 = "0"
     value_1 = "1"
     value_2 = "2"
+
 
 @unique
 class StrandEnum(str, Enum):
     """
     strand
     """
+
     value_0 = "+"
     value_1 = "-"
     value_2 = "."
     value_3 = "?"
+
 
 @unique
 class SequenceEnum(str, Enum):
     """
     type of sequence
     """
+
     NA = "NA"
     AA = "AA"
+
 
 @unique
 class PredicateQualifierEnum(str, Enum):
@@ -1494,6 +1514,7 @@ class PredicateQualifierEnum(str, Enum):
     constrained list of qualifying terms that soften or expand the definition of the predicate used. can be used to
     constrain or qualify any predicate (any child of related_to).
     """
+
     predicted = "predicted"
     possibly = "possibly"
     hypothesized = "hypothesized"
@@ -1501,11 +1522,13 @@ class PredicateQualifierEnum(str, Enum):
     value_4 = "supported by real-world evidence"
     value_5 = "supported by clinical evidence"
 
+
 @unique
 class DrugAvailabilityEnum(str, Enum):
 
     value_0 = "over the counter"
     prescription = "prescription"
+
 
 @unique
 class FDAApprovalStatusEnum(str, Enum):
@@ -1526,7 +1549,9 @@ class FDAApprovalStatusEnum(str, Enum):
     value_13 = "Regular FDA Approval"
     value_14 = "Post-Approval Withdrawal"
 
+
 # Classes
+
 
 @dataclass(config=PydanticConfig)
 class OntologyClass:
@@ -1538,13 +1563,7 @@ class OntologyClass:
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "MESH",
-        "UMLS",
-        "KEGG.BRITE"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["MESH", "UMLS", "KEGG.BRITE"]
 
 
 @dataclass(config=PydanticConfig)
@@ -1552,8 +1571,6 @@ class Annotation:
     """
     Biolink Model root class for entity annotations.
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1570,7 +1587,6 @@ class QuantityValue(Annotation):
     has_numeric_value: Optional[Union[float, float]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class Attribute(Annotation, OntologyClass):
     """
@@ -1580,16 +1596,13 @@ class Attribute(Annotation, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Attribute"
-    _id_prefixes: ClassVar[List[str]] = [
-        "EDAM-DATA",
-        "EDAM-FORMAT",
-        "EDAM-OPERATION",
-        "EDAM-TOPIC"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["EDAM-DATA", "EDAM-FORMAT", "EDAM-OPERATION", "EDAM-TOPIC"]
 
     has_attribute_type: Union[str, OntologyClass] = None
     name: Optional[Union[str, LabelType]] = None
-    has_quantitative_value: Optional[Union[List[Union[str, QuantityValue]], Union[str, QuantityValue]]] = field(default_factory=list)
+    has_quantitative_value: Optional[
+        Union[List[Union[str, QuantityValue]], Union[str, QuantityValue]]
+    ] = field(default_factory=list)
     has_qualitative_value: Optional[Union[URIorCURIE, NamedThing]] = None
     iri: Optional[IriType] = None
     source: Optional[Union[str, LabelType]] = None
@@ -1618,8 +1631,6 @@ class BiologicalSex(Attribute):
     _category: ClassVar[str] = "BiologicalSex"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PhenotypicSex(BiologicalSex):
     """
@@ -1628,8 +1639,6 @@ class PhenotypicSex(BiologicalSex):
 
     # Class Variables
     _category: ClassVar[str] = "PhenotypicSex"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1643,8 +1652,6 @@ class GenotypicSex(BiologicalSex):
     _category: ClassVar[str] = "GenotypicSex"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class SeverityValue(Attribute):
     """
@@ -1653,8 +1660,6 @@ class SeverityValue(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "SeverityValue"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1682,8 +1687,6 @@ class PathognomonicityQuantifier(SpecificityQuantifier):
     feature implies the existence of the disease
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class FrequencyQuantifier(RelationshipQuantifier):
@@ -1691,7 +1694,6 @@ class FrequencyQuantifier(RelationshipQuantifier):
     has_total: Optional[Union[int, int]] = None
     has_quotient: Optional[Union[float, float]] = None
     has_percentage: Optional[Union[float, float]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1705,31 +1707,34 @@ class Entity:
     """
     Root Biolink Model class for all things and informational relationships, real or imagined.
     """
-    id: URIorCURIE = None
+
+    id: Union[URIorCURIE, Entity] = None
     iri: Optional[IriType] = None
-    category: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
+    category: Optional[Union[List[Union[str, CategoryType]], Union[str, CategoryType]]] = field(
+        default_factory=list
+    )
     type: Optional[Union[str, str]] = None
     name: Optional[Union[str, LabelType]] = None
     description: Optional[Union[str, NarrativeText]] = None
     source: Optional[Union[str, LabelType]] = None
-    provided_by: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
-    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(default_factory=list)
+    provided_by: Optional[Union[List[Union[URIorCURIE, Agent]], Union[URIorCURIE, Agent]]] = field(
+        default_factory=list
+    )
+    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
     @validator('id', allow_reuse=True)
     def validate_required_id(cls, value):
         check_value_is_not_none("id", value)
-        check_curie_prefix(cls, value)
+        check_curie_prefix(Entity, value)
         return value
-
-    @validator('category', allow_reuse=True)
-    def convert_category_to_list_check_curies(cls, value):
-        return convert_scalar_to_list_check_curies(cls, value)
 
     @validator('provided_by', allow_reuse=True)
     def convert_provided_by_to_list_check_curies(cls, value):
-        return convert_scalar_to_list_check_curies(cls, value)
+        return convert_scalar_to_list_check_curies(Agent, value)
 
     @validator('has_attribute', allow_reuse=True)
     def convert_has_attribute_to_list_check_curies(cls, value):
@@ -1748,7 +1753,6 @@ class Entity:
             )
 
 
-
 @dataclass(config=PydanticConfig)
 class NamedThing(Entity):
     """
@@ -1758,15 +1762,7 @@ class NamedThing(Entity):
     # Class Variables
     _category: ClassVar[str] = "NamedThing"
 
-    category: Union[List[URIorCURIE], URIorCURIE] = None
-
-    # Validators
-
-    @validator('category', allow_reuse=True)
-    def validate_required_category(cls, value):
-        check_value_is_not_none("category", value)
-        convert_scalar_to_list_check_curies(cls, value)
-        return value
+    category: Union[List[Union[URIorCURIE, NamedThing]], Union[URIorCURIE, NamedThing]] = None
 
 
 @dataclass(config=PydanticConfig)
@@ -1779,15 +1775,11 @@ class RelationshipType(OntologyClass):
     _category: ClassVar[str] = "RelationshipType"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class GeneOntologyClass(OntologyClass):
     """
     an ontology class that describes a functional aspect of a gene, gene prodoct or complex
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1795,8 +1787,6 @@ class UnclassifiedOntologyClass(OntologyClass):
     """
     this is used for nodes that are taken from an ontology but are not typed using an existing biolink class
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1807,11 +1797,7 @@ class TaxonomicRank(OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "TaxonomicRank"
-    _id_prefixes: ClassVar[List[str]] = [
-        "TAXRANK"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["TAXRANK"]
 
 
 @dataclass(config=PydanticConfig)
@@ -1823,13 +1809,12 @@ class OrganismTaxon(NamedThing):
 
     # Class Variables
     _category: ClassVar[str] = "OrganismTaxon"
-    _id_prefixes: ClassVar[List[str]] = [
-        "NCBITaxon",
-        "MESH"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["NCBITaxon", "MESH"]
 
     has_taxonomic_rank: Optional[Union[str, TaxonomicRank]] = None
-    subclass_of: Optional[Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]] = field(default_factory=list)
+    subclass_of: Optional[
+        Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -1848,8 +1833,6 @@ class Event(NamedThing):
     _category: ClassVar[str] = "Event"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class AdministrativeEntity(NamedThing):
 
@@ -1864,17 +1847,12 @@ class Agent(AdministrativeEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Agent"
-    _id_prefixes: ClassVar[List[str]] = [
-        "isbn",
-        "ORCID",
-        "ScopusID",
-        "ResearchID",
-        "GSID",
-        "isni"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["isbn", "ORCID", "ScopusID", "ResearchID", "GSID", "isni"]
 
-    id: URIorCURIE = None
-    affiliation: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
+    id: Union[URIorCURIE, Agent] = None
+    affiliation: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
     address: Optional[Union[str, str]] = None
     name: Optional[Union[str, LabelType]] = None
 
@@ -1887,7 +1865,7 @@ class Agent(AdministrativeEntity):
     @validator('id', allow_reuse=True)
     def validate_required_id(cls, value):
         check_value_is_not_none("id", value)
-        check_curie_prefix(cls, value)
+        check_curie_prefix(Agent, value)
         return value
 
 
@@ -1898,15 +1876,12 @@ class InformationContentEntity(NamedThing):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "doi"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["doi"]
 
     license: Optional[Union[str, str]] = None
     rights: Optional[Union[str, str]] = None
     format: Optional[Union[str, str]] = None
     creation_date: Optional[Union[str, XSDDate]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1919,8 +1894,6 @@ class Dataset(InformationContentEntity):
     _category: ClassVar[str] = "Dataset"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class DatasetDistribution(InformationContentEntity):
     """
@@ -1931,7 +1904,6 @@ class DatasetDistribution(InformationContentEntity):
     _category: ClassVar[str] = "DatasetDistribution"
 
     distribution_download_url: Optional[Union[str, str]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1973,7 +1945,6 @@ class DatasetSummary(InformationContentEntity):
     source_logo: Optional[Union[str, str]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class ConfidenceLevel(InformationContentEntity):
     """
@@ -1984,8 +1955,6 @@ class ConfidenceLevel(InformationContentEntity):
     _category: ClassVar[str] = "ConfidenceLevel"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EvidenceType(InformationContentEntity):
     """
@@ -1994,8 +1963,6 @@ class EvidenceType(InformationContentEntity):
 
     # Class Variables
     _category: ClassVar[str] = "EvidenceType"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2012,8 +1979,6 @@ class InformationResource(InformationContentEntity):
     _category: ClassVar[str] = "InformationResource"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Publication(InformationContentEntity):
     """
@@ -2025,18 +1990,20 @@ class Publication(InformationContentEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Publication"
-    _id_prefixes: ClassVar[List[str]] = [
-        "NLMID"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["NLMID"]
 
-    id: URIorCURIE = None
+    id: Union[URIorCURIE, Publication] = None
     type: Union[str, str] = None
     authors: Optional[Union[List[Union[str, str]], Union[str, str]]] = field(default_factory=list)
     pages: Optional[Union[List[Union[str, str]], Union[str, str]]] = field(default_factory=list)
     summary: Optional[Union[str, str]] = None
     keywords: Optional[Union[List[Union[str, str]], Union[str, str]]] = field(default_factory=list)
-    mesh_terms: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
-    xref: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
+    mesh_terms: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
+    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
     name: Optional[Union[str, LabelType]] = None
 
     # Validators
@@ -2064,7 +2031,7 @@ class Publication(InformationContentEntity):
     @validator('id', allow_reuse=True)
     def validate_required_id(cls, value):
         check_value_is_not_none("id", value)
-        check_curie_prefix(cls, value)
+        check_curie_prefix(Publication, value)
         return value
 
     @validator('type', allow_reuse=True)
@@ -2081,12 +2048,9 @@ class Book(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Book"
-    _id_prefixes: ClassVar[List[str]] = [
-        "isbn",
-        "NLMID"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["isbn", "NLMID"]
 
-    id: URIorCURIE = None
+    id: Union[URIorCURIE, Book] = None
     type: Union[str, str] = None
 
     # Validators
@@ -2094,7 +2058,7 @@ class Book(Publication):
     @validator('id', allow_reuse=True)
     def validate_required_id(cls, value):
         check_value_is_not_none("id", value)
-        check_curie_prefix(cls, value)
+        check_curie_prefix(Book, value)
         return value
 
     @validator('type', allow_reuse=True)
@@ -2118,7 +2082,6 @@ class BookChapter(Publication):
     @validator('published_in', allow_reuse=True)
     def validate_required_published_in(cls, value):
         check_value_is_not_none("published_in", value)
-        check_curie_prefix(cls, value)
         return value
 
 
@@ -2130,12 +2093,9 @@ class Serial(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Serial"
-    _id_prefixes: ClassVar[List[str]] = [
-        "issn",
-        "NLMID"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["issn", "NLMID"]
 
-    id: URIorCURIE = None
+    id: Union[URIorCURIE, Serial] = None
     type: Union[str, str] = None
     iso_abbreviation: Optional[Union[str, str]] = None
     volume: Optional[Union[str, str]] = None
@@ -2146,7 +2106,7 @@ class Serial(Publication):
     @validator('id', allow_reuse=True)
     def validate_required_id(cls, value):
         check_value_is_not_none("id", value)
-        check_curie_prefix(cls, value)
+        check_curie_prefix(Serial, value)
         return value
 
     @validator('type', allow_reuse=True)
@@ -2160,9 +2120,7 @@ class Article(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Article"
-    _id_prefixes: ClassVar[List[str]] = [
-        "PMID"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["PMID"]
 
     published_in: Union[str, URIorCURIE] = None
     iso_abbreviation: Optional[Union[str, str]] = None
@@ -2174,7 +2132,6 @@ class Article(Publication):
     @validator('published_in', allow_reuse=True)
     def validate_required_published_in(cls, value):
         check_value_is_not_none("published_in", value)
-        check_curie_prefix(cls, value)
         return value
 
 
@@ -2184,16 +2141,12 @@ class PhysicalEssenceOrOccurrent:
     Either a physical or processual entity.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class PhysicalEssence(PhysicalEssenceOrOccurrent):
     """
     Semantic mixin concept.  Pertains to entities that have physical properties such as mass, volume, or charge.
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2206,15 +2159,11 @@ class PhysicalEntity(NamedThing, PhysicalEssence):
     _category: ClassVar[str] = "PhysicalEntity"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Occurrent(PhysicalEssenceOrOccurrent):
     """
     A processual entity.
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2222,8 +2171,6 @@ class ActivityAndBehavior(Occurrent):
     """
     Activity or behavior of any independent integral living, organization or mechanical actor in the world
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2237,8 +2184,6 @@ class Activity(NamedThing, ActivityAndBehavior):
     _category: ClassVar[str] = "Activity"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Procedure(NamedThing, ActivityAndBehavior):
     """
@@ -2247,8 +2192,6 @@ class Procedure(NamedThing, ActivityAndBehavior):
 
     # Class Variables
     _category: ClassVar[str] = "Procedure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2261,8 +2204,6 @@ class Phenomenon(NamedThing, Occurrent):
     _category: ClassVar[str] = "Phenomenon"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Device(NamedThing):
     """
@@ -2273,15 +2214,11 @@ class Device(NamedThing):
     _category: ClassVar[str] = "Device"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class SubjectOfInvestigation:
     """
     An entity that has the role of being studied in an investigation, study, or experiment
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2294,12 +2231,7 @@ class MaterialSample(PhysicalEntity, SubjectOfInvestigation):
 
     # Class Variables
     _category: ClassVar[str] = "MaterialSample"
-    _id_prefixes: ClassVar[List[str]] = [
-        "BIOSAMPLE",
-        "GOLD.META"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["BIOSAMPLE", "GOLD.META"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2312,8 +2244,6 @@ class PlanetaryEntity(NamedThing):
     _category: ClassVar[str] = "PlanetaryEntity"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EnvironmentalProcess(PlanetaryEntity, Occurrent):
 
@@ -2321,15 +2251,11 @@ class EnvironmentalProcess(PlanetaryEntity, Occurrent):
     _category: ClassVar[str] = "EnvironmentalProcess"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EnvironmentalFeature(PlanetaryEntity):
 
     # Class Variables
     _category: ClassVar[str] = "EnvironmentalFeature"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2345,7 +2271,6 @@ class GeographicLocation(PlanetaryEntity):
     longitude: Optional[Union[float, float]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class GeographicLocationAtTime(GeographicLocation):
     """
@@ -2356,7 +2281,6 @@ class GeographicLocationAtTime(GeographicLocation):
     _category: ClassVar[str] = "GeographicLocationAtTime"
 
     timepoint: Optional[Union[str, TimeType]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2371,7 +2295,10 @@ class ThingWithTaxon:
     A mixin that can be used on any entity that can be taxonomically classified. This includes individual organisms;
     genes, their products and other molecular entities; body parts; biological processes
     """
-    in_taxon: Optional[Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]] = field(default_factory=list)
+
+    in_taxon: Optional[
+        Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -2385,14 +2312,11 @@ class GenomicEntity(ThingWithTaxon):
     has_biological_sequence: Optional[Union[str, BiologicalSequence]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class ChemicalSubstance:
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalSubstance"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2404,14 +2328,23 @@ class BiologicalProcessOrActivity(BiologicalEntity, Occurrent, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "BiologicalProcessOrActivity"
-    _id_prefixes: ClassVar[List[str]] = [
-        "GO",
-        "REACT"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT"]
 
-    has_input: Optional[Union[List[Union[URIorCURIE, BiologicalProcessOrActivity]], Union[URIorCURIE, BiologicalProcessOrActivity]]] = field(default_factory=list)
-    has_output: Optional[Union[List[Union[URIorCURIE, BiologicalProcessOrActivity]], Union[URIorCURIE, BiologicalProcessOrActivity]]] = field(default_factory=list)
-    enabled_by: Optional[Union[List[Union[URIorCURIE, PhysicalEntity]], Union[URIorCURIE, PhysicalEntity]]] = field(default_factory=list)
+    has_input: Optional[
+        Union[
+            List[Union[URIorCURIE, BiologicalProcessOrActivity]],
+            Union[URIorCURIE, BiologicalProcessOrActivity],
+        ]
+    ] = field(default_factory=list)
+    has_output: Optional[
+        Union[
+            List[Union[URIorCURIE, BiologicalProcessOrActivity]],
+            Union[URIorCURIE, BiologicalProcessOrActivity],
+        ]
+    ] = field(default_factory=list)
+    enabled_by: Optional[
+        Union[List[Union[URIorCURIE, PhysicalEntity]], Union[URIorCURIE, PhysicalEntity]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -2450,12 +2383,18 @@ class MolecularActivity(BiologicalProcessOrActivity, Occurrent, OntologyClass):
         "UMLS",
         "BIGG.REACTION",
         "SEED.REACTION",
-        "METANETX.REACTION"
+        "METANETX.REACTION",
     ]
 
-    has_input: Optional[Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]] = field(default_factory=list)
-    has_output: Optional[Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]] = field(default_factory=list)
-    enabled_by: Optional[Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]] = field(default_factory=list)
+    has_input: Optional[
+        Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]
+    ] = field(default_factory=list)
+    has_output: Optional[
+        Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]
+    ] = field(default_factory=list)
+    enabled_by: Optional[
+        Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -2480,14 +2419,7 @@ class BiologicalProcess(BiologicalProcessOrActivity, Occurrent, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "BiologicalProcess"
-    _id_prefixes: ClassVar[List[str]] = [
-        "GO",
-        "REACT",
-        "MetaCyc",
-        "KEGG.MODULE"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT", "MetaCyc", "KEGG.MODULE"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2505,10 +2437,8 @@ class Pathway(BiologicalProcess, OntologyClass):
         "WIKIPATHWAYS",
         "FB",
         "PANTHER.PATHWAY",
-        "KEGG.PATHWAY"
+        "KEGG.PATHWAY",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2516,12 +2446,7 @@ class PhysiologicalProcess(BiologicalProcess, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "PhysiologicalProcess"
-    _id_prefixes: ClassVar[List[str]] = [
-        "GO",
-        "REACT"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2529,8 +2454,6 @@ class Behavior(BiologicalProcess, ActivityAndBehavior, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Behavior"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2543,8 +2466,6 @@ class OrganismAttribute(Attribute):
     _category: ClassVar[str] = "OrganismAttribute"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PhenotypicQuality(OrganismAttribute):
     """
@@ -2553,8 +2474,6 @@ class PhenotypicQuality(OrganismAttribute):
 
     # Class Variables
     _category: ClassVar[str] = "PhenotypicQuality"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2568,15 +2487,16 @@ class Inheritance(OrganismAttribute):
     _category: ClassVar[str] = "Inheritance"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class OrganismalEntity(BiologicalEntity):
     """
     A named entity that is either a part of an organism, a whole organism, population or clade of organisms, excluding
     chemical entities
     """
-    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(default_factory=list)
+
+    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -2595,8 +2515,6 @@ class LifeStage(OrganismalEntity, ThingWithTaxon):
     _category: ClassVar[str] = "LifeStage"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class IndividualOrganism(OrganismalEntity, ThingWithTaxon):
     """
@@ -2606,11 +2524,7 @@ class IndividualOrganism(OrganismalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "IndividualOrganism"
-    _id_prefixes: ClassVar[List[str]] = [
-        "ORCID"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["ORCID"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2623,11 +2537,7 @@ class PopulationOfIndividualOrganisms(OrganismalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "PopulationOfIndividualOrganisms"
-    _id_prefixes: ClassVar[List[str]] = [
-        "HANCESTRO"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["HANCESTRO"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2640,8 +2550,6 @@ class StudyPopulation(PopulationOfIndividualOrganisms):
     _category: ClassVar[str] = "StudyPopulation"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class DiseaseOrPhenotypicFeature(BiologicalEntity, ThingWithTaxon):
     """
@@ -2651,8 +2559,6 @@ class DiseaseOrPhenotypicFeature(BiologicalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeature"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2677,10 +2583,8 @@ class Disease(DiseaseOrPhenotypicFeature):
         "ICD0",
         "KEGG.DISEASE",
         "HP",
-        "MP"
+        "MP",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2703,10 +2607,8 @@ class PhenotypicFeature(DiseaseOrPhenotypicFeature):
         "SNOMEDCT",
         "MESH",
         "XPO",
-        "FYPO"
+        "FYPO",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2719,8 +2621,6 @@ class BehavioralFeature(PhenotypicFeature):
     _category: ClassVar[str] = "BehavioralFeature"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class AnatomicalEntity(OrganismalEntity, ThingWithTaxon, PhysicalEssence):
     """
@@ -2729,16 +2629,7 @@ class AnatomicalEntity(OrganismalEntity, ThingWithTaxon, PhysicalEssence):
 
     # Class Variables
     _category: ClassVar[str] = "AnatomicalEntity"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UBERON",
-        "GO",
-        "CL",
-        "UMLS",
-        "MESH",
-        "NCIT"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UBERON", "GO", "CL", "UMLS", "MESH", "NCIT"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2749,17 +2640,7 @@ class CellularComponent(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "CellularComponent"
-    _id_prefixes: ClassVar[List[str]] = [
-        "GO",
-        "MESH",
-        "UMLS",
-        "NCIT",
-        "SNOMEDCT",
-        "CL",
-        "UBERON"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["GO", "MESH", "UMLS", "NCIT", "SNOMEDCT", "CL", "UBERON"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2767,17 +2648,7 @@ class Cell(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Cell"
-    _id_prefixes: ClassVar[List[str]] = [
-        "CL",
-        "PO",
-        "UMLS",
-        "NCIT",
-        "MESH",
-        "UBERON",
-        "SNOMEDCT"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["CL", "PO", "UMLS", "NCIT", "MESH", "UBERON", "SNOMEDCT"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2785,11 +2656,7 @@ class CellLine(OrganismalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "CellLine"
-    _id_prefixes: ClassVar[List[str]] = [
-        "CLO"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["CLO"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2797,16 +2664,7 @@ class GrossAnatomicalStructure(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "GrossAnatomicalStructure"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UBERON",
-        "UMLS",
-        "MESH",
-        "NCIT",
-        "PO",
-        "FAO"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UBERON", "UMLS", "MESH", "NCIT", "PO", "FAO"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2816,8 +2674,6 @@ class ChemicalEntityOrGeneOrGeneProduct:
     across chemical entities that must include genes and their children as chemical entities.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class ChemicalEntityOrProteinOrPolypeptide:
@@ -2826,26 +2682,27 @@ class ChemicalEntityOrProteinOrPolypeptide:
     searching across chemical entities that must include genes and their children as chemical entities.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
-class ChemicalEntity(NamedThing, PhysicalEssence, ChemicalOrDrugOrTreatment, ChemicalEntityOrGeneOrGeneProduct, ChemicalEntityOrProteinOrPolypeptide):
+class ChemicalEntity(
+    NamedThing,
+    PhysicalEssence,
+    ChemicalOrDrugOrTreatment,
+    ChemicalEntityOrGeneOrGeneProduct,
+    ChemicalEntityOrProteinOrPolypeptide,
+):
     """
     A chemical entity is a physical entity that pertains to chemistry or biochemistry.
     """
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalEntity"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UNII",
-        "MESH",
-        "CAS",
-        "UMLS"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["UNII", "MESH", "CAS", "UMLS"]
 
     trade_name: Optional[Union[URIorCURIE, ChemicalEntity]] = None
-    available_from: Optional[Union[List[Union[str, DrugAvailabilityEnum]], Union[str, DrugAvailabilityEnum]]] = field(default_factory=list)
+    available_from: Optional[
+        Union[List[Union[str, DrugAvailabilityEnum]], Union[str, DrugAvailabilityEnum]]
+    ] = field(default_factory=list)
     max_tolerated_dose: Optional[Union[str, str]] = None
     is_toxic: Optional[Union[bool, Bool]] = None
 
@@ -2891,11 +2748,10 @@ class MolecularEntity(ChemicalEntity):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
-        "UMLS"
+        "UMLS",
     ]
 
     is_metabolite: Optional[Union[bool, Bool]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2932,17 +2788,17 @@ class SmallMolecule(MolecularEntity):
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
         "BIGG.METABOLITE",
-        "UMLS"
+        "UMLS",
     ]
 
-    id: URIorCURIE = None
+    id: Union[URIorCURIE, SmallMolecule] = None
 
     # Validators
 
     @validator('id', allow_reuse=True)
     def validate_required_id(cls, value):
         check_value_is_not_none("id", value)
-        check_curie_prefix(cls, value)
+        check_curie_prefix(SmallMolecule, value)
         return value
 
 
@@ -2976,7 +2832,7 @@ class ChemicalMixture(ChemicalEntity):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
-        "UMLS"
+        "UMLS",
     ]
 
     is_supplement: Optional[Union[URIorCURIE, ChemicalMixture]] = None
@@ -3017,10 +2873,8 @@ class NucleicAcidEntity(MolecularEntity, GenomicEntity, PhysicalEssence, Ontolog
         "INCHI",
         "INCHIKEY",
         "KEGG.GLYCAN",
-        "KEGG.ENVIRON"
+        "KEGG.ENVIRON",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3054,10 +2908,8 @@ class MolecularMixture(ChemicalMixture):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
-        "UMLS"
+        "UMLS",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3091,10 +2943,8 @@ class ComplexMolecularMixture(ChemicalMixture):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
-        "UMLS"
+        "UMLS",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3106,11 +2956,7 @@ class ProcessedMaterial(ChemicalMixture):
 
     # Class Variables
     _category: ClassVar[str] = "ProcessedMaterial"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UMLS"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UMLS"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3121,13 +2967,7 @@ class Drug(MolecularMixture, ChemicalOrDrugOrTreatment, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Drug"
-    _id_prefixes: ClassVar[List[str]] = [
-        "RXCUI",
-        "NDC",
-        "UMLS"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["RXCUI", "NDC", "UMLS"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3137,15 +2977,11 @@ class EnvironmentalFoodContaminant(ChemicalEntity):
     _category: ClassVar[str] = "EnvironmentalFoodContaminant"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class FoodAdditive(ChemicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "FoodAdditive"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3155,15 +2991,11 @@ class Nutrient(ChemicalEntity):
     _category: ClassVar[str] = "Nutrient"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Macronutrient(Nutrient):
 
     # Class Variables
     _category: ClassVar[str] = "Macronutrient"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3173,15 +3005,11 @@ class Micronutrient(Nutrient):
     _category: ClassVar[str] = "Micronutrient"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Vitamin(Micronutrient):
 
     # Class Variables
     _category: ClassVar[str] = "Vitamin"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3192,11 +3020,7 @@ class Food(ChemicalMixture):
 
     # Class Variables
     _category: ClassVar[str] = "Food"
-    _id_prefixes: ClassVar[List[str]] = [
-        "foodb.compound"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["foodb.compound"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3205,8 +3029,8 @@ class MacromolecularMachineMixin:
     A union of gene locus, gene product, and macromolecular complex mixin. These are the basic units of function in a
     cell. They either carry out individual biological activities, or they encode molecules which do this.
     """
-    name: Optional[Union[str, SymbolType]] = None
 
+    name: Optional[Union[str, SymbolType]] = None
 
 
 @dataclass(config=PydanticConfig)
@@ -3216,16 +3040,18 @@ class GeneOrGeneProduct(MacromolecularMachineMixin):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "CHEMBL.TARGET",
-        "IUPHAR.FAMILY"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["CHEMBL.TARGET", "IUPHAR.FAMILY"]
 
 
 @dataclass(config=PydanticConfig)
-class Gene(BiologicalEntity, GeneOrGeneProduct, GenomicEntity, ChemicalEntityOrGeneOrGeneProduct, PhysicalEssence, OntologyClass):
+class Gene(
+    BiologicalEntity,
+    GeneOrGeneProduct,
+    GenomicEntity,
+    ChemicalEntityOrGeneOrGeneProduct,
+    PhysicalEssence,
+    OntologyClass,
+):
     """
     A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A
     gene locus may include regulatory regions, transcribed regions and/or other functional sequence regions.
@@ -3249,12 +3075,16 @@ class Gene(BiologicalEntity, GeneOrGeneProduct, GenomicEntity, ChemicalEntityOrG
         "OMIM",
         "KEGG.GENE",
         "UMLS",
-        "Xenbase"
+        "Xenbase",
     ]
 
     symbol: Optional[Union[str, str]] = None
-    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(default_factory=list)
-    xref: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
+    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(
+        default_factory=list
+    )
+    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -3275,14 +3105,14 @@ class GeneProductMixin(GeneOrGeneProduct):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "UniProtKB",
-        "gtpo",
-        "PR"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "gtpo", "PR"]
 
-    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(default_factory=list)
-    xref: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
+    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(
+        default_factory=list
+    )
+    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -3303,8 +3133,6 @@ class GeneProductIsoformMixin(GeneProductMixin):
     designation of canonical or reference may be arbitrary, or it may represent the superclass of all isoforms.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class MacromolecularComplexMixin(MacromolecularMachineMixin):
@@ -3314,14 +3142,7 @@ class MacromolecularComplexMixin(MacromolecularMachineMixin):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "INTACT",
-        "GO",
-        "PR",
-        "REACT"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["INTACT", "GO", "PR", "REACT"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3332,8 +3153,6 @@ class Genome(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Genome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3347,8 +3166,6 @@ class Exon(NucleicAcidEntity):
     _category: ClassVar[str] = "Exon"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Transcript(NucleicAcidEntity):
     """
@@ -3357,12 +3174,7 @@ class Transcript(NucleicAcidEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Transcript"
-    _id_prefixes: ClassVar[List[str]] = [
-        "ENSEMBL",
-        "FB"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["ENSEMBL", "FB"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3372,10 +3184,13 @@ class CodingSequence(NucleicAcidEntity):
     _category: ClassVar[str] = "CodingSequence"
 
 
-
-
 @dataclass(config=PydanticConfig)
-class Polypeptide(BiologicalEntity, ThingWithTaxon, ChemicalEntityOrGeneOrGeneProduct, ChemicalEntityOrProteinOrPolypeptide):
+class Polypeptide(
+    BiologicalEntity,
+    ThingWithTaxon,
+    ChemicalEntityOrGeneOrGeneProduct,
+    ChemicalEntityOrProteinOrPolypeptide,
+):
     """
     A polypeptide is a molecular entity characterized by availability in protein databases of amino-acid-based
     sequence representations of its precise primary structure; for convenience of representation, partial sequences of
@@ -3384,15 +3199,7 @@ class Polypeptide(BiologicalEntity, ThingWithTaxon, ChemicalEntityOrGeneOrGenePr
 
     # Class Variables
     _category: ClassVar[str] = "Polypeptide"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UniProtKB",
-        "PR",
-        "ENSEMBL",
-        "FB",
-        "UMLS"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "PR", "ENSEMBL", "FB", "UMLS"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3404,16 +3211,7 @@ class Protein(Polypeptide, GeneProductMixin, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "Protein"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UniProtKB",
-        "PR",
-        "ENSEMBL",
-        "FB",
-        "UMLS",
-        "MESH"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "PR", "ENSEMBL", "FB", "UMLS", "MESH"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3425,14 +3223,7 @@ class ProteinIsoform(Protein, GeneProductIsoformMixin):
 
     # Class Variables
     _category: ClassVar[str] = "ProteinIsoform"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UniProtKB",
-        "UNIPROT.ISOFORM",
-        "PR",
-        "ENSEMBL"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "UNIPROT.ISOFORM", "PR", "ENSEMBL"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3440,11 +3231,7 @@ class RNAProduct(Transcript, GeneProductMixin):
 
     # Class Variables
     _category: ClassVar[str] = "RNAProduct"
-    _id_prefixes: ClassVar[List[str]] = [
-        "RNACENTRAL"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3455,11 +3242,7 @@ class RNAProductIsoform(RNAProduct, GeneProductIsoformMixin):
 
     # Class Variables
     _category: ClassVar[str] = "RNAProductIsoform"
-    _id_prefixes: ClassVar[List[str]] = [
-        "RNACENTRAL"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3467,13 +3250,7 @@ class NoncodingRNAProduct(RNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "NoncodingRNAProduct"
-    _id_prefixes: ClassVar[List[str]] = [
-        "RNACENTRAL",
-        "NCBIGene",
-        "ENSEMBL"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL", "NCBIGene", "ENSEMBL"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3481,13 +3258,7 @@ class MicroRNA(NoncodingRNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "MicroRNA"
-    _id_prefixes: ClassVar[List[str]] = [
-        "MIR",
-        "HGNC",
-        "WormBase"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["MIR", "HGNC", "WormBase"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3500,13 +3271,7 @@ class SiRNA(NoncodingRNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "SiRNA"
-    _id_prefixes: ClassVar[List[str]] = [
-        "MIR",
-        "HGNC",
-        "WormBase"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["MIR", "HGNC", "WormBase"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3514,7 +3279,10 @@ class GeneGroupingMixin:
     """
     any grouping of multiple genes or gene products
     """
-    has_gene_or_gene_product: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(default_factory=list)
+
+    has_gene_or_gene_product: Optional[
+        Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -3551,10 +3319,8 @@ class GeneFamily(BiologicalEntity, GeneGroupingMixin, ChemicalEntityOrGeneOrGene
         "RFAM",
         "KEGG.ORTHOLOGY",
         "EGGNOG",
-        "COG"
+        "COG",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3562,8 +3328,6 @@ class Zygosity(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "Zygosity"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3575,13 +3339,9 @@ class Genotype(BiologicalEntity, PhysicalEssence, GenomicEntity, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Genotype"
-    _id_prefixes: ClassVar[List[str]] = [
-        "ZFIN",
-        "FB"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["ZFIN", "FB"]
 
     has_zygosity: Optional[Union[str, Zygosity]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3592,8 +3352,6 @@ class Haplotype(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass)
 
     # Class Variables
     _category: ClassVar[str] = "Haplotype"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3614,11 +3372,13 @@ class SequenceVariant(BiologicalEntity, GenomicEntity, PhysicalEssence, Ontology
         "ZFIN",
         "FB",
         "WB",
-        "WormBase"
+        "WormBase",
     ]
 
-    id: URIorCURIE = None
-    has_gene: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(default_factory=list)
+    id: Union[URIorCURIE, SequenceVariant] = None
+    has_gene: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(
+        default_factory=list
+    )
     has_biological_sequence: Optional[Union[str, BiologicalSequence]] = None
 
     # Validators
@@ -3630,7 +3390,7 @@ class SequenceVariant(BiologicalEntity, GenomicEntity, PhysicalEssence, Ontology
     @validator('id', allow_reuse=True)
     def validate_required_id(cls, value):
         check_value_is_not_none("id", value)
-        check_curie_prefix(cls, value)
+        check_curie_prefix(SequenceVariant, value)
         return value
 
 
@@ -3644,8 +3404,6 @@ class Snv(SequenceVariant):
     _category: ClassVar[str] = "Snv"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ReagentTargetedGene(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass):
     """
@@ -3657,8 +3415,6 @@ class ReagentTargetedGene(BiologicalEntity, GenomicEntity, PhysicalEssence, Onto
     _category: ClassVar[str] = "ReagentTargetedGene"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ClinicalAttribute(Attribute):
     """
@@ -3667,8 +3423,6 @@ class ClinicalAttribute(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalAttribute"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3702,8 +3456,6 @@ class ClinicalModifier(ClinicalAttribute):
     _category: ClassVar[str] = "ClinicalModifier"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ClinicalCourse(ClinicalAttribute):
     """
@@ -3715,8 +3467,6 @@ class ClinicalCourse(ClinicalAttribute):
     _category: ClassVar[str] = "ClinicalCourse"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Onset(ClinicalCourse):
     """
@@ -3725,8 +3475,6 @@ class Onset(ClinicalCourse):
 
     # Class Variables
     _category: ClassVar[str] = "Onset"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3740,8 +3488,6 @@ class ClinicalEntity(NamedThing):
     _category: ClassVar[str] = "ClinicalEntity"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ClinicalTrial(ClinicalEntity):
 
@@ -3749,15 +3495,11 @@ class ClinicalTrial(ClinicalEntity):
     _category: ClassVar[str] = "ClinicalTrial"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ClinicalIntervention(ClinicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalIntervention"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3769,13 +3511,11 @@ class ClinicalFinding(PhenotypicFeature):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalFinding"
-    _id_prefixes: ClassVar[List[str]] = [
-        "LOINC",
-        "NCIT",
-        "EFO"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["LOINC", "NCIT", "EFO"]
 
-    has_attribute: Optional[Union[List[Union[str, ClinicalAttribute]], Union[str, ClinicalAttribute]]] = field(default_factory=list)
+    has_attribute: Optional[
+        Union[List[Union[str, ClinicalAttribute]], Union[str, ClinicalAttribute]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -3791,8 +3531,6 @@ class Hospitalization(ClinicalIntervention):
     _category: ClassVar[str] = "Hospitalization"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class SocioeconomicAttribute(Attribute):
     """
@@ -3803,8 +3541,6 @@ class SocioeconomicAttribute(Attribute):
     _category: ClassVar[str] = "SocioeconomicAttribute"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Case(IndividualOrganism):
     """
@@ -3813,8 +3549,6 @@ class Case(IndividualOrganism):
 
     # Class Variables
     _category: ClassVar[str] = "Case"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3828,20 +3562,20 @@ class Cohort(StudyPopulation):
     _category: ClassVar[str] = "Cohort"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ExposureEvent:
     """
     A (possibly time bounded) incidence of a feature of the environment of an organism that influences one or more
     phenotypic features of that organism, potentially mediated by genes
     """
+
     timepoint: Optional[Union[str, TimeType]] = None
 
 
-
 @dataclass(config=PydanticConfig)
-class GenomicBackgroundExposure(ExposureEvent, GeneGroupingMixin, PhysicalEssence, GenomicEntity, OntologyClass):
+class GenomicBackgroundExposure(
+    ExposureEvent, GeneGroupingMixin, PhysicalEssence, GenomicEntity, OntologyClass
+):
     """
     A genomic background exposure is where an individual's specific genomic background of genes, sequence variants or
     other pre-existing genomic conditions constitute a kind of 'exposure' to the organism, leading to or influencing
@@ -3852,15 +3586,11 @@ class GenomicBackgroundExposure(ExposureEvent, GeneGroupingMixin, PhysicalEssenc
     _category: ClassVar[str] = "GenomicBackgroundExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PathologicalEntityMixin:
     """
     A pathological (abnormal) structure or process.
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -3874,8 +3604,6 @@ class PathologicalProcess(BiologicalProcess, PathologicalEntityMixin):
     _category: ClassVar[str] = "PathologicalProcess"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PathologicalProcessExposure(ExposureEvent):
     """
@@ -3885,8 +3613,6 @@ class PathologicalProcessExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalProcessExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3900,8 +3626,6 @@ class PathologicalAnatomicalStructure(AnatomicalEntity, PathologicalEntityMixin)
     _category: ClassVar[str] = "PathologicalAnatomicalStructure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PathologicalAnatomicalExposure(ExposureEvent):
     """
@@ -3911,8 +3635,6 @@ class PathologicalAnatomicalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalAnatomicalExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3927,8 +3649,6 @@ class DiseaseOrPhenotypicFeatureExposure(ExposureEvent, PathologicalEntityMixin)
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeatureExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ChemicalExposure(ExposureEvent):
     """
@@ -3937,8 +3657,6 @@ class ChemicalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3951,8 +3669,6 @@ class ComplexChemicalExposure:
     _category: ClassVar[str] = "ComplexChemicalExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class DrugExposure(ChemicalExposure, ExposureEvent):
     """
@@ -3961,8 +3677,6 @@ class DrugExposure(ChemicalExposure, ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "DrugExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3976,8 +3690,6 @@ class DrugToGeneInteractionExposure(DrugExposure, GeneGroupingMixin):
     _category: ClassVar[str] = "DrugToGeneInteractionExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Treatment(NamedThing, ExposureEvent, ChemicalOrDrugOrTreatment):
     """
@@ -3988,9 +3700,15 @@ class Treatment(NamedThing, ExposureEvent, ChemicalOrDrugOrTreatment):
     # Class Variables
     _category: ClassVar[str] = "Treatment"
 
-    has_drug: Optional[Union[List[Union[URIorCURIE, Drug]], Union[URIorCURIE, Drug]]] = field(default_factory=list)
-    has_device: Optional[Union[List[Union[URIorCURIE, Device]], Union[URIorCURIE, Device]]] = field(default_factory=list)
-    has_procedure: Optional[Union[List[Union[URIorCURIE, Procedure]], Union[URIorCURIE, Procedure]]] = field(default_factory=list)
+    has_drug: Optional[Union[List[Union[URIorCURIE, Drug]], Union[URIorCURIE, Drug]]] = field(
+        default_factory=list
+    )
+    has_device: Optional[Union[List[Union[URIorCURIE, Device]], Union[URIorCURIE, Device]]] = field(
+        default_factory=list
+    )
+    has_procedure: Optional[
+        Union[List[Union[URIorCURIE, Procedure]], Union[URIorCURIE, Procedure]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -4017,8 +3735,6 @@ class BioticExposure(ExposureEvent):
     _category: ClassVar[str] = "BioticExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EnvironmentalExposure(ExposureEvent):
     """
@@ -4028,8 +3744,6 @@ class EnvironmentalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "EnvironmentalExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4042,8 +3756,6 @@ class GeographicExposure(EnvironmentalExposure, ExposureEvent):
     _category: ClassVar[str] = "GeographicExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class BehavioralExposure(ExposureEvent):
     """
@@ -4052,8 +3764,6 @@ class BehavioralExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "BehavioralExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4066,7 +3776,9 @@ class SocioeconomicExposure(ExposureEvent):
     # Class Variables
     _category: ClassVar[str] = "SocioeconomicExposure"
 
-    has_attribute: Union[List[Union[str, SocioeconomicAttribute]], Union[str, SocioeconomicAttribute]] = None
+    has_attribute: Union[
+        List[Union[str, SocioeconomicAttribute]], Union[str, SocioeconomicAttribute]
+    ] = None
 
     # Validators
 
@@ -4084,8 +3796,6 @@ class Outcome:
     various categories of possible biological or non-biological (e.g. clinical) outcomes.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class PathologicalProcessOutcome(Outcome):
@@ -4097,8 +3807,6 @@ class PathologicalProcessOutcome(Outcome):
     _category: ClassVar[str] = "PathologicalProcessOutcome"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PathologicalAnatomicalOutcome(Outcome):
     """
@@ -4107,8 +3815,6 @@ class PathologicalAnatomicalOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalAnatomicalOutcome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4122,8 +3828,6 @@ class DiseaseOrPhenotypicFeatureOutcome(Outcome):
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeatureOutcome"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class BehavioralOutcome(Outcome):
     """
@@ -4132,8 +3836,6 @@ class BehavioralOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "BehavioralOutcome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4147,8 +3849,6 @@ class HospitalizationOutcome(Outcome):
     _category: ClassVar[str] = "HospitalizationOutcome"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class MortalityOutcome(Outcome):
     """
@@ -4157,8 +3857,6 @@ class MortalityOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "MortalityOutcome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4171,8 +3869,6 @@ class EpidemiologicalOutcome(Outcome):
     _category: ClassVar[str] = "EpidemiologicalOutcome"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class SocioeconomicOutcome(Outcome):
     """
@@ -4182,8 +3878,6 @@ class SocioeconomicOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "SocioeconomicOutcome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4200,11 +3894,19 @@ class Association(Entity):
     object: Union[URIorCURIE, NamedThing] = None
     relation: Optional[Union[str, str]] = None
     negated: Optional[Union[bool, Bool]] = None
-    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(default_factory=list)
-    publications: Optional[Union[List[Union[URIorCURIE, Publication]], Union[URIorCURIE, Publication]]] = field(default_factory=list)
-    has_evidence: Optional[Union[List[Union[URIorCURIE, EvidenceType]], Union[URIorCURIE, EvidenceType]]] = field(default_factory=list)
+    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(
+        default_factory=list
+    )
+    publications: Optional[
+        Union[List[Union[URIorCURIE, Publication]], Union[URIorCURIE, Publication]]
+    ] = field(default_factory=list)
+    has_evidence: Optional[
+        Union[List[Union[URIorCURIE, EvidenceType]], Union[URIorCURIE, EvidenceType]]
+    ] = field(default_factory=list)
     type: Optional[Union[str, str]] = None
-    category: Optional[Union[List[URIorCURIE], URIorCURIE]] = field(default_factory=list)
+    category: Optional[Union[List[Union[str, CategoryType]], Union[str, CategoryType]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -4237,10 +3939,6 @@ class Association(Entity):
     def convert_has_evidence_to_list_check_curies(cls, value):
         return convert_scalar_to_list_check_curies(EvidenceType, value)
 
-    @validator('category', allow_reuse=True)
-    def convert_category_to_list_check_curies(cls, value):
-        return convert_scalar_to_list_check_curies(cls, value)
-
 
 @dataclass(config=PydanticConfig)
 class ContributorAssociation(Association):
@@ -4254,7 +3952,9 @@ class ContributorAssociation(Association):
     subject: Union[URIorCURIE, InformationContentEntity] = None
     predicate: Union[str, PredicateType] = None
     object: Union[URIorCURIE, Agent] = None
-    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(default_factory=list)
+    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -4386,6 +4086,7 @@ class GeneToGeneAssociation(Association):
     abstract parent class for different kinds of gene-gene or gene product to gene product relationships. Includes
     homology and interaction.
     """
+
     subject: Union[str, GeneOrGeneProduct] = None
     object: Union[str, GeneOrGeneProduct] = None
 
@@ -4428,6 +4129,7 @@ class GeneExpressionMixin:
     Observed gene expression intensity, context (site, stage) and associated phenotypic status within which the
     expression occurs.
     """
+
     quantifier_qualifier: Optional[Union[str, OntologyClass]] = None
     expression_site: Optional[Union[URIorCURIE, AnatomicalEntity]] = None
     stage_qualifier: Optional[Union[URIorCURIE, LifeStage]] = None
@@ -4501,7 +4203,7 @@ class PairwiseMolecularInteraction(PairwiseGeneToGeneInteraction):
     _category: ClassVar[str] = "PairwiseMolecularInteraction"
 
     subject: Union[URIorCURIE, MolecularEntity] = None
-    id: URIorCURIE = None
+    id: Union[URIorCURIE, PairwiseMolecularInteraction] = None
     predicate: Union[str, PredicateType] = None
     object: Union[URIorCURIE, MolecularEntity] = None
     interacting_molecules_category: Optional[Union[str, OntologyClass]] = None
@@ -4518,7 +4220,7 @@ class PairwiseMolecularInteraction(PairwiseGeneToGeneInteraction):
     @validator('id', allow_reuse=True)
     def validate_required_id(cls, value):
         check_value_is_not_none("id", value)
-        check_curie_prefix(cls, value)
+        check_curie_prefix(PairwiseMolecularInteraction, value)
         return value
 
     @validator('predicate', allow_reuse=True)
@@ -4538,6 +4240,7 @@ class CellLineToEntityAssociationMixin:
     """
     An relationship between a cell line and another entity
     """
+
     subject: Union[URIorCURIE, CellLine] = None
 
     # Validators
@@ -4554,6 +4257,7 @@ class ChemicalEntityToEntityAssociationMixin:
     """
     An interaction between a chemical entity and another entity
     """
+
     subject: Union[str, ChemicalEntityOrGeneOrGeneProduct] = None
 
     # Validators
@@ -4569,6 +4273,7 @@ class DrugToEntityAssociationMixin(ChemicalEntityToEntityAssociationMixin):
     """
     An interaction between a drug and another entity
     """
+
     subject: Union[URIorCURIE, Drug] = None
 
     # Validators
@@ -4585,6 +4290,7 @@ class ChemicalToEntityAssociationMixin(ChemicalEntityToEntityAssociationMixin):
     """
     An interaction between a chemical entity and another entity
     """
+
     subject: Union[str, ChemicalEntityOrGeneOrGeneProduct] = None
 
     # Validators
@@ -4600,6 +4306,7 @@ class CaseToEntityAssociationMixin:
     """
     An abstract association for use where the case is the subject
     """
+
     subject: Union[URIorCURIE, Case] = None
 
     # Validators
@@ -4688,7 +4395,9 @@ class ChemicalToChemicalDerivationAssociation(ChemicalToChemicalAssociation):
     subject: Union[URIorCURIE, ChemicalEntity] = None
     object: Union[URIorCURIE, ChemicalEntity] = None
     predicate: Union[str, PredicateType] = None
-    catalyst_qualifier: Optional[Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]] = field(default_factory=list)
+    catalyst_qualifier: Optional[
+        Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -4777,6 +4486,7 @@ class MaterialSampleToEntityAssociationMixin:
     """
     An association between a material sample and something.
     """
+
     subject: Union[URIorCURIE, MaterialSample] = None
 
     # Validators
@@ -4839,6 +4549,7 @@ class EntityToExposureEventAssociationMixin:
     """
     An association between some entity and an exposure event.
     """
+
     object: Union[str, ExposureEvent] = None
 
     # Validators
@@ -4850,15 +4561,15 @@ class EntityToExposureEventAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseToExposureEventAssociation(Association, DiseaseToEntityAssociationMixin, EntityToExposureEventAssociationMixin):
+class DiseaseToExposureEventAssociation(
+    Association, DiseaseToEntityAssociationMixin, EntityToExposureEventAssociationMixin
+):
     """
     An association between an exposure event and a disease.
     """
 
     # Class Variables
     _category: ClassVar[str] = "DiseaseToExposureEventAssociation"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4868,13 +4579,12 @@ class ExposureEventToEntityAssociationMixin:
     _category: ClassVar[str] = "ExposureEventToEntityAssociationMixin"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EntityToOutcomeAssociationMixin:
     """
     An association between some entity and an outcome
     """
+
     object: Union[str, Outcome] = None
 
     # Validators
@@ -4886,7 +4596,9 @@ class EntityToOutcomeAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class ExposureEventToOutcomeAssociation(Association, ExposureEventToEntityAssociationMixin, EntityToOutcomeAssociationMixin):
+class ExposureEventToOutcomeAssociation(
+    Association, ExposureEventToEntityAssociationMixin, EntityToOutcomeAssociationMixin
+):
     """
     An association between an exposure event and an outcome.
     """
@@ -4910,8 +4622,8 @@ class FrequencyQualifierMixin:
     """
     Qualifier for frequency type associations
     """
-    frequency_qualifier: Optional[Union[str, FrequencyValue]] = None
 
+    frequency_qualifier: Optional[Union[str, FrequencyValue]] = None
 
 
 @dataclass(config=PydanticConfig)
@@ -4919,9 +4631,9 @@ class EntityToFeatureOrDiseaseQualifiersMixin(FrequencyQualifierMixin):
     """
     Qualifiers for entity to disease or phenotype associations.
     """
+
     severity_qualifier: Optional[Union[str, SeverityValue]] = None
     onset_qualifier: Optional[Union[str, Onset]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4982,6 +4694,7 @@ class EntityToDiseaseAssociationMixin(EntityToFeatureOrDiseaseQualifiersMixin):
     """
     mixin class for any association whose object (target node) is a disease
     """
+
     object: Union[URIorCURIE, Disease] = None
 
     # Validators
@@ -5007,7 +4720,9 @@ class DiseaseOrPhenotypicFeatureToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseOrPhenotypicFeatureToLocationAssociation(Association, DiseaseOrPhenotypicFeatureToEntityAssociationMixin):
+class DiseaseOrPhenotypicFeatureToLocationAssociation(
+    Association, DiseaseOrPhenotypicFeatureToEntityAssociationMixin
+):
     """
     An association between either a disease or a phenotypic feature and an anatomical entity, where the
     disease/feature manifests in that site.
@@ -5041,7 +4756,11 @@ class EntityToDiseaseOrPhenotypicFeatureAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class CellLineToDiseaseOrPhenotypicFeatureAssociation(Association, CellLineToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
+class CellLineToDiseaseOrPhenotypicFeatureAssociation(
+    Association,
+    CellLineToEntityAssociationMixin,
+    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
+):
     """
     An relationship between a cell line and a disease or a phenotype, where the cell line is derived from an
     individual with that disease or phenotype.
@@ -5062,7 +4781,11 @@ class CellLineToDiseaseOrPhenotypicFeatureAssociation(Association, CellLineToEnt
 
 
 @dataclass(config=PydanticConfig)
-class ChemicalToDiseaseOrPhenotypicFeatureAssociation(Association, ChemicalToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
+class ChemicalToDiseaseOrPhenotypicFeatureAssociation(
+    Association,
+    ChemicalToEntityAssociationMixin,
+    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
+):
     """
     An interaction between a chemical entity and a phenotype or disease, where the presence of the chemical gives rise
     to or exacerbates the phenotype.
@@ -5083,15 +4806,17 @@ class ChemicalToDiseaseOrPhenotypicFeatureAssociation(Association, ChemicalToEnt
 
 
 @dataclass(config=PydanticConfig)
-class MaterialSampleToDiseaseOrPhenotypicFeatureAssociation(Association, MaterialSampleToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
+class MaterialSampleToDiseaseOrPhenotypicFeatureAssociation(
+    Association,
+    MaterialSampleToEntityAssociationMixin,
+    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
+):
     """
     An association between a material sample and a disease or phenotype.
     """
 
     # Class Variables
     _category: ClassVar[str] = "MaterialSampleToDiseaseOrPhenotypicFeatureAssociation"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -5108,7 +4833,9 @@ class GenotypeToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, GenotypeToEntityAssociationMixin):
+class GenotypeToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin, GenotypeToEntityAssociationMixin
+):
     """
     Any association between one genotype and a phenotypic feature, where having the genotype confers the phenotype,
     either in isolation or through environment
@@ -5135,7 +4862,9 @@ class GenotypeToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeat
 
 
 @dataclass(config=PydanticConfig)
-class ExposureEventToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin):
+class ExposureEventToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin
+):
     """
     Any association between an environment and a phenotypic feature, where being in the environment influences the
     phenotype.
@@ -5155,7 +4884,9 @@ class ExposureEventToPhenotypicFeatureAssociation(Association, EntityToPhenotypi
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, DiseaseToEntityAssociationMixin):
+class DiseaseToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin, DiseaseToEntityAssociationMixin
+):
     """
     An association between a disease and a phenotypic feature in which the phenotypic feature is associated with the
     disease in some way.
@@ -5165,10 +4896,10 @@ class DiseaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatu
     _category: ClassVar[str] = "DiseaseToPhenotypicFeatureAssociation"
 
 
-
-
 @dataclass(config=PydanticConfig)
-class CaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, CaseToEntityAssociationMixin):
+class CaseToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin, CaseToEntityAssociationMixin
+):
     """
     An association between a case (e.g. individual patient) and a phenotypic feature in which the individual has or
     has had the phenotype.
@@ -5178,10 +4909,10 @@ class CaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureA
     _category: ClassVar[str] = "CaseToPhenotypicFeatureAssociation"
 
 
-
-
 @dataclass(config=PydanticConfig)
-class BehaviorToBehavioralFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin):
+class BehaviorToBehavioralFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin
+):
     """
     An association between an mixture behavior and a behavioral feature manifested by the individual exhibited or has
     exhibited the behavior.
@@ -5234,7 +4965,9 @@ class VariantToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GeneToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, GeneToEntityAssociationMixin):
+class GeneToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin, GeneToEntityAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GeneToPhenotypicFeatureAssociation"
@@ -5250,7 +4983,9 @@ class GeneToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureA
 
 
 @dataclass(config=PydanticConfig)
-class GeneToDiseaseAssociation(Association, EntityToDiseaseAssociationMixin, GeneToEntityAssociationMixin):
+class GeneToDiseaseAssociation(
+    Association, EntityToDiseaseAssociationMixin, GeneToEntityAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GeneToDiseaseAssociation"
@@ -5312,7 +5047,9 @@ class VariantToGeneExpressionAssociation(VariantToGeneAssociation, GeneExpressio
 
 
 @dataclass(config=PydanticConfig)
-class VariantToPopulationAssociation(Association, VariantToEntityAssociationMixin, FrequencyQuantifier, FrequencyQualifierMixin):
+class VariantToPopulationAssociation(
+    Association, VariantToEntityAssociationMixin, FrequencyQuantifier, FrequencyQualifierMixin
+):
     """
     An association between a variant and a population, where the variant has particular frequency in the population
     """
@@ -5375,7 +5112,9 @@ class PopulationToPopulationAssociation(Association):
 
 
 @dataclass(config=PydanticConfig)
-class VariantToPhenotypicFeatureAssociation(Association, VariantToEntityAssociationMixin, EntityToPhenotypicFeatureAssociationMixin):
+class VariantToPhenotypicFeatureAssociation(
+    Association, VariantToEntityAssociationMixin, EntityToPhenotypicFeatureAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "VariantToPhenotypicFeatureAssociation"
@@ -5392,7 +5131,9 @@ class VariantToPhenotypicFeatureAssociation(Association, VariantToEntityAssociat
 
 
 @dataclass(config=PydanticConfig)
-class VariantToDiseaseAssociation(Association, VariantToEntityAssociationMixin, EntityToDiseaseAssociationMixin):
+class VariantToDiseaseAssociation(
+    Association, VariantToEntityAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "VariantToDiseaseAssociation"
@@ -5422,7 +5163,9 @@ class VariantToDiseaseAssociation(Association, VariantToEntityAssociationMixin, 
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeToDiseaseAssociation(Association, GenotypeToEntityAssociationMixin, EntityToDiseaseAssociationMixin):
+class GenotypeToDiseaseAssociation(
+    Association, GenotypeToEntityAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GenotypeToDiseaseAssociation"
@@ -5458,6 +5201,7 @@ class ModelToDiseaseAssociationMixin:
     that it recapitulates some features of the disease in a way that is useful for studying the disease outside a
     patient carrying the disease
     """
+
     subject: Union[URIorCURIE, NamedThing] = None
     predicate: Union[str, PredicateType] = None
 
@@ -5476,7 +5220,9 @@ class ModelToDiseaseAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GeneAsAModelOfDiseaseAssociation(GeneToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class GeneAsAModelOfDiseaseAssociation(
+    GeneToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GeneAsAModelOfDiseaseAssociation"
@@ -5492,7 +5238,9 @@ class GeneAsAModelOfDiseaseAssociation(GeneToDiseaseAssociation, ModelToDiseaseA
 
 
 @dataclass(config=PydanticConfig)
-class VariantAsAModelOfDiseaseAssociation(VariantToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class VariantAsAModelOfDiseaseAssociation(
+    VariantToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "VariantAsAModelOfDiseaseAssociation"
@@ -5509,7 +5257,9 @@ class VariantAsAModelOfDiseaseAssociation(VariantToDiseaseAssociation, ModelToDi
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeAsAModelOfDiseaseAssociation(GenotypeToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class GenotypeAsAModelOfDiseaseAssociation(
+    GenotypeToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GenotypeAsAModelOfDiseaseAssociation"
@@ -5526,7 +5276,11 @@ class GenotypeAsAModelOfDiseaseAssociation(GenotypeToDiseaseAssociation, ModelTo
 
 
 @dataclass(config=PydanticConfig)
-class CellLineAsAModelOfDiseaseAssociation(CellLineToDiseaseOrPhenotypicFeatureAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class CellLineAsAModelOfDiseaseAssociation(
+    CellLineToDiseaseOrPhenotypicFeatureAssociation,
+    ModelToDiseaseAssociationMixin,
+    EntityToDiseaseAssociationMixin,
+):
 
     # Class Variables
     _category: ClassVar[str] = "CellLineAsAModelOfDiseaseAssociation"
@@ -5543,7 +5297,9 @@ class CellLineAsAModelOfDiseaseAssociation(CellLineToDiseaseOrPhenotypicFeatureA
 
 
 @dataclass(config=PydanticConfig)
-class OrganismalEntityAsAModelOfDiseaseAssociation(Association, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class OrganismalEntityAsAModelOfDiseaseAssociation(
+    Association, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "OrganismalEntityAsAModelOfDiseaseAssociation"
@@ -5676,6 +5432,7 @@ class SequenceVariantModulatesTreatmentAssociation(Association):
     An association between a sequence variant and a treatment or health intervention. The treatment object itself
     encompasses both the disease and the drug used.
     """
+
     subject: Union[URIorCURIE, SequenceVariant] = None
     object: Union[URIorCURIE, Treatment] = None
 
@@ -5725,6 +5482,7 @@ class MacromolecularMachineToEntityAssociationMixin:
     """
     an association which has a macromolecular machine mixin as a subject
     """
+
     subject: Union[URIorCURIE, NamedThing] = None
 
     # Validators
@@ -5737,7 +5495,9 @@ class MacromolecularMachineToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToMolecularActivityAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
+class MacromolecularMachineToMolecularActivityAssociation(
+    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
+):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a molecular activity
     (as represented in the GO molecular function branch), where the entity carries out the activity, or contributes to
@@ -5759,7 +5519,9 @@ class MacromolecularMachineToMolecularActivityAssociation(FunctionalAssociation,
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToBiologicalProcessAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
+class MacromolecularMachineToBiologicalProcessAssociation(
+    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
+):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a biological process
     or pathway (as represented in the GO biological process branch), where the entity carries out some part of the
@@ -5781,7 +5543,9 @@ class MacromolecularMachineToBiologicalProcessAssociation(FunctionalAssociation,
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToCellularComponentAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
+class MacromolecularMachineToCellularComponentAssociation(
+    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
+):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a cellular component
     (as represented in the GO cellular component branch), where the entity carries out its function in the cellular
@@ -5890,7 +5654,6 @@ class EntityToDiseaseAssociation(Association):
     FDA_approval_status: Optional[Union[str, FDAApprovalStatusEnum]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class EntityToPhenotypicFeatureAssociation(Association):
 
@@ -5898,7 +5661,6 @@ class EntityToPhenotypicFeatureAssociation(Association):
     _category: ClassVar[str] = "EntityToPhenotypicFeatureAssociation"
 
     FDA_approval_status: Optional[Union[str, FDAApprovalStatusEnum]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -5909,8 +5671,6 @@ class SequenceAssociation(Association):
 
     # Class Variables
     _category: ClassVar[str] = "SequenceAssociation"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -6117,7 +5877,9 @@ class AnatomicalEntityToAnatomicalEntityAssociation(Association):
 
 
 @dataclass(config=PydanticConfig)
-class AnatomicalEntityToAnatomicalEntityPartOfAssociation(AnatomicalEntityToAnatomicalEntityAssociation):
+class AnatomicalEntityToAnatomicalEntityPartOfAssociation(
+    AnatomicalEntityToAnatomicalEntityAssociation
+):
     """
     A relationship between two anatomical entities where the relationship is mereological, i.e the two entities are
     related by parthood. This includes relationships between cellular components and cells, between cells and tissues,
@@ -6152,7 +5914,9 @@ class AnatomicalEntityToAnatomicalEntityPartOfAssociation(AnatomicalEntityToAnat
 
 
 @dataclass(config=PydanticConfig)
-class AnatomicalEntityToAnatomicalEntityOntogenicAssociation(AnatomicalEntityToAnatomicalEntityAssociation):
+class AnatomicalEntityToAnatomicalEntityOntogenicAssociation(
+    AnatomicalEntityToAnatomicalEntityAssociation
+):
     """
     A relationship between two anatomical entities where the relationship is ontogenic, i.e. the two entities are
     related by development. A number of different relationship types can be used to specify the precise nature of the
@@ -6191,6 +5955,7 @@ class OrganismTaxonToEntityAssociation:
     """
     An association between an organism taxon and another entity
     """
+
     subject: Union[URIorCURIE, OrganismTaxon] = None
 
     # Validators
@@ -6207,6 +5972,7 @@ class OrganismTaxonToOrganismTaxonAssociation(Association, OrganismTaxonToEntity
     """
     A relationship between two organism taxon nodes
     """
+
     subject: Union[URIorCURIE, OrganismTaxon] = None
     object: Union[URIorCURIE, OrganismTaxon] = None
 
@@ -6581,5 +6347,3 @@ OrganismTaxonToOrganismTaxonAssociation.__pydantic_model__.update_forward_refs()
 OrganismTaxonToOrganismTaxonSpecialization.__pydantic_model__.update_forward_refs()
 OrganismTaxonToOrganismTaxonInteraction.__pydantic_model__.update_forward_refs()
 OrganismTaxonToEnvironmentAssociation.__pydantic_model__.update_forward_refs()
-
-

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -52,6 +52,15 @@ def test_bad_curie_prefix(caplog):
     assert caplog.records[1].msg.startswith("Consider one of ['NCBITaxon', 'MESH']")
 
 
+def test_empty_local_id_emits_warning(caplog):
+    """
+    Test that misformatted curie in a list returns a validation error
+    """
+    gen_ent = Gene(id='NCBIGene:')
+    assert caplog.records[0].levelname == 'WARNING'
+    assert caplog.records[0].msg.startswith("NCBIGene: does not have a local identifier")
+
+
 def test_good_curie():
     """
     Tests that a properly formatted curie works, and


### PR DESCRIPTION
- Change valid_prefixes from a list to a set in pydanticgen
- Add an option to exclude custom validators
- Add an option to selectively exclude validation on certain slots, in our case we can exclude "category" for the monarch ingests since this is populated automatically based on the inheritance chain
- Emit a warning when creating a curie without a local identifier, eg "SomePrefix:"

closes #16

partially addresses #4