### PR TITLE
Fixed split error in curie validation

### DIFF
--- a/biolink_model_pydantic/__init__.py
+++ b/biolink_model_pydantic/__init__.py
@@ -1,2 +1,2 @@
 """Pydantic dataclasses for the Biolink model"""
-__version__ = '0.1.6'
+__version__ = '0.1.7'

--- a/biolink_model_pydantic/model.py
+++ b/biolink_model_pydantic/model.py
@@ -1,5 +1,5 @@
 # Auto generated from biolink-model.yaml by pydanticgen.py version: 0.9.0
-# Generation date: 2022-02-22T13:22:51
+# Generation date: 2022-03-14T16:23:52
 # Schema: Biolink-Model
 #
 # id: https://w3id.org/biolink/biolink-model
@@ -23,7 +23,9 @@ from pydantic.dataclasses import dataclass
 LOG = logging.getLogger(__name__)
 
 metamodel_version = "1.7.0"
-curie_regexp = r'^[a-zA-Z_]?[a-zA-Z_0-9.-]*:([A-Za-z0-9_][A-Za-z0-9_.-]*[A-Za-z0-9./\(\)\-><_:;]*)?$'
+curie_regexp = (
+    r'^[a-zA-Z_]?[a-zA-Z_0-9.-]*:([A-Za-z0-9_][A-Za-z0-9_.-]*[A-Za-z0-9./\(\)\-><_:;]*)?$'
+)
 curie_pattern = re.compile(curie_regexp)
 
 # Type Aliases
@@ -1056,7 +1058,7 @@ valid_prefix = {
     "void",
     "wgs",
     "xml",
-    "xsd"
+    "xsd",
 }
 
 
@@ -1072,6 +1074,7 @@ class PydanticConfig:
     underscore_attrs_are_private = True
     extra = 'forbid'
     arbitrary_types_allowed = True  # TODO re-evaluate this
+
 
 # Pydantic Validators
 def check_curie_prefix(cls, curie: Union[List, str, None]):
@@ -1089,7 +1092,7 @@ def check_curie_prefix(cls, curie: Union[List, str, None]):
                         f"for a list of valid curie prefixes"
                     )
     elif curie:
-        prefix, local_id = curie.split(':')
+        prefix, local_id = curie.split(':', 1)
         if prefix not in valid_prefix:
             LOG.warning(f"{curie} prefix '{prefix}' not in curie map")
             if hasattr(cls, '_id_prefixes') and cls._id_prefixes:
@@ -1101,7 +1104,6 @@ def check_curie_prefix(cls, curie: Union[List, str, None]):
                 )
         if local_id == '':
             LOG.warning(f"{curie} does not have a local identifier")
-
 
 
 def convert_scalar_to_list_check_curies(cls, value: Any) -> List[str]:
@@ -1152,8 +1154,12 @@ class PredicateType(str, Enum):
     acts_upstream_of = "biolink:acts_upstream_of"
     acts_upstream_of_negative_effect = "biolink:acts_upstream_of_negative_effect"
     acts_upstream_of_or_within = "biolink:acts_upstream_of_or_within"
-    acts_upstream_of_or_within_negative_effect = "biolink:acts_upstream_of_or_within_negative_effect"
-    acts_upstream_of_or_within_positive_effect = "biolink:acts_upstream_of_or_within_positive_effect"
+    acts_upstream_of_or_within_negative_effect = (
+        "biolink:acts_upstream_of_or_within_negative_effect"
+    )
+    acts_upstream_of_or_within_positive_effect = (
+        "biolink:acts_upstream_of_or_within_positive_effect"
+    )
     acts_upstream_of_positive_effect = "biolink:acts_upstream_of_positive_effect"
     adverse_event_caused_by = "biolink:adverse_event_caused_by"
     affected_by = "biolink:affected_by"
@@ -1294,7 +1300,9 @@ class PredicateType(str, Enum):
     has_plasma_membrane_part = "biolink:has_plasma_membrane_part"
     has_positive_upstream_actor = "biolink:has_positive_upstream_actor"
     has_positive_upstream_or_within_actor = "biolink:has_positive_upstream_or_within_actor"
-    has_real_world_evidence_of_association_with = "biolink:has_real_world_evidence_of_association_with"
+    has_real_world_evidence_of_association_with = (
+        "biolink:has_real_world_evidence_of_association_with"
+    )
     has_sequence_location = "biolink:has_sequence_location"
     has_sequence_variant = "biolink:has_sequence_variant"
     has_splice_site_variant = "biolink:has_splice_site_variant"
@@ -1447,6 +1455,7 @@ class PredicateType(str, Enum):
     variant_part_of = "biolink:variant_part_of"
     xenologous_to = "biolink:xenologous_to"
 
+
 Predicate = namedtuple(
     'biolink_predicate', [pred.value.replace('biolink:', '') for pred in PredicateType]
 )(*[pred.value for pred in PredicateType])
@@ -1460,6 +1469,7 @@ class LogicalInterpretationEnum(str, Enum):
     AllSome = "AllSome"
     InverseAllSome = "InverseAllSome"
 
+
 @unique
 class ReactionDirectionEnum(str, Enum):
 
@@ -1468,38 +1478,46 @@ class ReactionDirectionEnum(str, Enum):
     bidirectional = "bidirectional"
     neutral = "neutral"
 
+
 @unique
 class ReactionSideEnum(str, Enum):
 
     left = "left"
     right = "right"
 
+
 @unique
 class PhaseEnum(str, Enum):
     """
     phase
     """
+
     value_0 = "0"
     value_1 = "1"
     value_2 = "2"
+
 
 @unique
 class StrandEnum(str, Enum):
     """
     strand
     """
+
     value_0 = "+"
     value_1 = "-"
     value_2 = "."
     value_3 = "?"
+
 
 @unique
 class SequenceEnum(str, Enum):
     """
     type of sequence
     """
+
     NA = "NA"
     AA = "AA"
+
 
 @unique
 class PredicateQualifierEnum(str, Enum):
@@ -1507,6 +1525,7 @@ class PredicateQualifierEnum(str, Enum):
     constrained list of qualifying terms that soften or expand the definition of the predicate used. can be used to
     constrain or qualify any predicate (any child of related_to).
     """
+
     predicted = "predicted"
     possibly = "possibly"
     hypothesized = "hypothesized"
@@ -1514,11 +1533,13 @@ class PredicateQualifierEnum(str, Enum):
     value_4 = "supported by real-world evidence"
     value_5 = "supported by clinical evidence"
 
+
 @unique
 class DrugAvailabilityEnum(str, Enum):
 
     value_0 = "over the counter"
     prescription = "prescription"
+
 
 @unique
 class FDAApprovalStatusEnum(str, Enum):
@@ -1539,7 +1560,9 @@ class FDAApprovalStatusEnum(str, Enum):
     value_13 = "Regular FDA Approval"
     value_14 = "Post-Approval Withdrawal"
 
+
 # Classes
+
 
 @dataclass(config=PydanticConfig)
 class OntologyClass:
@@ -1551,13 +1574,7 @@ class OntologyClass:
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "MESH",
-        "UMLS",
-        "KEGG.BRITE"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["MESH", "UMLS", "KEGG.BRITE"]
 
 
 @dataclass(config=PydanticConfig)
@@ -1565,8 +1582,6 @@ class Annotation:
     """
     Biolink Model root class for entity annotations.
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1583,7 +1598,6 @@ class QuantityValue(Annotation):
     has_numeric_value: Optional[Union[float, float]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class Attribute(Annotation, OntologyClass):
     """
@@ -1593,16 +1607,13 @@ class Attribute(Annotation, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Attribute"
-    _id_prefixes: ClassVar[List[str]] = [
-        "EDAM-DATA",
-        "EDAM-FORMAT",
-        "EDAM-OPERATION",
-        "EDAM-TOPIC"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["EDAM-DATA", "EDAM-FORMAT", "EDAM-OPERATION", "EDAM-TOPIC"]
 
     has_attribute_type: Union[str, OntologyClass] = None
     name: Optional[Union[str, LabelType]] = None
-    has_quantitative_value: Optional[Union[List[Union[str, QuantityValue]], Union[str, QuantityValue]]] = field(default_factory=list)
+    has_quantitative_value: Optional[
+        Union[List[Union[str, QuantityValue]], Union[str, QuantityValue]]
+    ] = field(default_factory=list)
     has_qualitative_value: Optional[Union[URIorCURIE, NamedThing]] = None
     iri: Optional[IriType] = None
     source: Optional[Union[str, LabelType]] = None
@@ -1631,8 +1642,6 @@ class BiologicalSex(Attribute):
     _category: ClassVar[str] = "BiologicalSex"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PhenotypicSex(BiologicalSex):
     """
@@ -1641,8 +1650,6 @@ class PhenotypicSex(BiologicalSex):
 
     # Class Variables
     _category: ClassVar[str] = "PhenotypicSex"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1656,8 +1663,6 @@ class GenotypicSex(BiologicalSex):
     _category: ClassVar[str] = "GenotypicSex"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class SeverityValue(Attribute):
     """
@@ -1666,8 +1671,6 @@ class SeverityValue(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "SeverityValue"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1695,8 +1698,6 @@ class PathognomonicityQuantifier(SpecificityQuantifier):
     feature implies the existence of the disease
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class FrequencyQuantifier(RelationshipQuantifier):
@@ -1704,7 +1705,6 @@ class FrequencyQuantifier(RelationshipQuantifier):
     has_total: Optional[Union[int, int]] = None
     has_quotient: Optional[Union[float, float]] = None
     has_percentage: Optional[Union[float, float]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1718,15 +1718,22 @@ class Entity:
     """
     Root Biolink Model class for all things and informational relationships, real or imagined.
     """
+
     id: Union[URIorCURIE, Entity] = None
     iri: Optional[IriType] = None
-    category: Optional[Union[List[Union[str, CategoryType]], Union[str, CategoryType]]] = field(default_factory=list)
+    category: Optional[Union[List[Union[str, CategoryType]], Union[str, CategoryType]]] = field(
+        default_factory=list
+    )
     type: Optional[Union[str, str]] = None
     name: Optional[Union[str, LabelType]] = None
     description: Optional[Union[str, NarrativeText]] = None
     source: Optional[Union[str, LabelType]] = None
-    provided_by: Optional[Union[List[Union[URIorCURIE, Agent]], Union[URIorCURIE, Agent]]] = field(default_factory=list)
-    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(default_factory=list)
+    provided_by: Optional[Union[List[Union[URIorCURIE, Agent]], Union[URIorCURIE, Agent]]] = field(
+        default_factory=list
+    )
+    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -1757,7 +1764,6 @@ class Entity:
             )
 
 
-
 @dataclass(config=PydanticConfig)
 class NamedThing(Entity):
     """
@@ -1770,7 +1776,6 @@ class NamedThing(Entity):
     category: Union[List[Union[URIorCURIE, NamedThing]], Union[URIorCURIE, NamedThing]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class RelationshipType(OntologyClass):
     """
@@ -1781,15 +1786,11 @@ class RelationshipType(OntologyClass):
     _category: ClassVar[str] = "RelationshipType"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class GeneOntologyClass(OntologyClass):
     """
     an ontology class that describes a functional aspect of a gene, gene prodoct or complex
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1797,8 +1798,6 @@ class UnclassifiedOntologyClass(OntologyClass):
     """
     this is used for nodes that are taken from an ontology but are not typed using an existing biolink class
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -1809,11 +1808,7 @@ class TaxonomicRank(OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "TaxonomicRank"
-    _id_prefixes: ClassVar[List[str]] = [
-        "TAXRANK"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["TAXRANK"]
 
 
 @dataclass(config=PydanticConfig)
@@ -1825,13 +1820,9 @@ class OrganismTaxon(NamedThing):
 
     # Class Variables
     _category: ClassVar[str] = "OrganismTaxon"
-    _id_prefixes: ClassVar[List[str]] = [
-        "NCBITaxon",
-        "MESH"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["NCBITaxon", "MESH"]
 
     has_taxonomic_rank: Optional[Union[str, TaxonomicRank]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1842,8 +1833,6 @@ class Event(NamedThing):
 
     # Class Variables
     _category: ClassVar[str] = "Event"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1860,17 +1849,12 @@ class Agent(AdministrativeEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Agent"
-    _id_prefixes: ClassVar[List[str]] = [
-        "isbn",
-        "ORCID",
-        "ScopusID",
-        "ResearchID",
-        "GSID",
-        "isni"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["isbn", "ORCID", "ScopusID", "ResearchID", "GSID", "isni"]
 
     id: Union[URIorCURIE, Agent] = None
-    affiliation: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
+    affiliation: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
     address: Optional[Union[str, str]] = None
     name: Optional[Union[str, LabelType]] = None
 
@@ -1894,15 +1878,12 @@ class InformationContentEntity(NamedThing):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "doi"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["doi"]
 
     license: Optional[Union[str, str]] = None
     rights: Optional[Union[str, str]] = None
     format: Optional[Union[str, str]] = None
     creation_date: Optional[Union[str, XSDDate]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1915,8 +1896,6 @@ class Dataset(InformationContentEntity):
     _category: ClassVar[str] = "Dataset"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class DatasetDistribution(InformationContentEntity):
     """
@@ -1927,7 +1906,6 @@ class DatasetDistribution(InformationContentEntity):
     _category: ClassVar[str] = "DatasetDistribution"
 
     distribution_download_url: Optional[Union[str, str]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -1969,7 +1947,6 @@ class DatasetSummary(InformationContentEntity):
     source_logo: Optional[Union[str, str]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class ConfidenceLevel(InformationContentEntity):
     """
@@ -1980,8 +1957,6 @@ class ConfidenceLevel(InformationContentEntity):
     _category: ClassVar[str] = "ConfidenceLevel"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EvidenceType(InformationContentEntity):
     """
@@ -1990,8 +1965,6 @@ class EvidenceType(InformationContentEntity):
 
     # Class Variables
     _category: ClassVar[str] = "EvidenceType"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2008,8 +1981,6 @@ class InformationResource(InformationContentEntity):
     _category: ClassVar[str] = "InformationResource"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Publication(InformationContentEntity):
     """
@@ -2021,9 +1992,7 @@ class Publication(InformationContentEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Publication"
-    _id_prefixes: ClassVar[List[str]] = [
-        "NLMID"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["NLMID"]
 
     id: Union[URIorCURIE, Publication] = None
     type: Union[str, str] = None
@@ -2031,8 +2000,12 @@ class Publication(InformationContentEntity):
     pages: Optional[Union[List[Union[str, str]], Union[str, str]]] = field(default_factory=list)
     summary: Optional[Union[str, str]] = None
     keywords: Optional[Union[List[Union[str, str]], Union[str, str]]] = field(default_factory=list)
-    mesh_terms: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
-    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
+    mesh_terms: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
+    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
     name: Optional[Union[str, LabelType]] = None
 
     # Validators
@@ -2077,10 +2050,7 @@ class Book(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Book"
-    _id_prefixes: ClassVar[List[str]] = [
-        "isbn",
-        "NLMID"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["isbn", "NLMID"]
 
     id: Union[URIorCURIE, Book] = None
     type: Union[str, str] = None
@@ -2125,10 +2095,7 @@ class Serial(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Serial"
-    _id_prefixes: ClassVar[List[str]] = [
-        "issn",
-        "NLMID"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["issn", "NLMID"]
 
     id: Union[URIorCURIE, Serial] = None
     type: Union[str, str] = None
@@ -2155,9 +2122,7 @@ class Article(Publication):
 
     # Class Variables
     _category: ClassVar[str] = "Article"
-    _id_prefixes: ClassVar[List[str]] = [
-        "PMID"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["PMID"]
 
     published_in: Union[str, URIorCURIE] = None
     iso_abbreviation: Optional[Union[str, str]] = None
@@ -2178,16 +2143,12 @@ class PhysicalEssenceOrOccurrent:
     Either a physical or processual entity.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class PhysicalEssence(PhysicalEssenceOrOccurrent):
     """
     Semantic mixin concept.  Pertains to entities that have physical properties such as mass, volume, or charge.
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2200,15 +2161,11 @@ class PhysicalEntity(NamedThing, PhysicalEssence):
     _category: ClassVar[str] = "PhysicalEntity"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Occurrent(PhysicalEssenceOrOccurrent):
     """
     A processual entity.
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2216,8 +2173,6 @@ class ActivityAndBehavior(Occurrent):
     """
     Activity or behavior of any independent integral living, organization or mechanical actor in the world
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2231,8 +2186,6 @@ class Activity(NamedThing, ActivityAndBehavior):
     _category: ClassVar[str] = "Activity"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Procedure(NamedThing, ActivityAndBehavior):
     """
@@ -2241,8 +2194,6 @@ class Procedure(NamedThing, ActivityAndBehavior):
 
     # Class Variables
     _category: ClassVar[str] = "Procedure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2255,8 +2206,6 @@ class Phenomenon(NamedThing, Occurrent):
     _category: ClassVar[str] = "Phenomenon"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Device(NamedThing):
     """
@@ -2267,15 +2216,11 @@ class Device(NamedThing):
     _category: ClassVar[str] = "Device"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class SubjectOfInvestigation:
     """
     An entity that has the role of being studied in an investigation, study, or experiment
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -2288,12 +2233,7 @@ class MaterialSample(PhysicalEntity, SubjectOfInvestigation):
 
     # Class Variables
     _category: ClassVar[str] = "MaterialSample"
-    _id_prefixes: ClassVar[List[str]] = [
-        "BIOSAMPLE",
-        "GOLD.META"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["BIOSAMPLE", "GOLD.META"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2306,8 +2246,6 @@ class PlanetaryEntity(NamedThing):
     _category: ClassVar[str] = "PlanetaryEntity"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EnvironmentalProcess(PlanetaryEntity, Occurrent):
 
@@ -2315,15 +2253,11 @@ class EnvironmentalProcess(PlanetaryEntity, Occurrent):
     _category: ClassVar[str] = "EnvironmentalProcess"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EnvironmentalFeature(PlanetaryEntity):
 
     # Class Variables
     _category: ClassVar[str] = "EnvironmentalFeature"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2339,7 +2273,6 @@ class GeographicLocation(PlanetaryEntity):
     longitude: Optional[Union[float, float]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class GeographicLocationAtTime(GeographicLocation):
     """
@@ -2350,7 +2283,6 @@ class GeographicLocationAtTime(GeographicLocation):
     _category: ClassVar[str] = "GeographicLocationAtTime"
 
     timepoint: Optional[Union[str, TimeType]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2365,7 +2297,10 @@ class ThingWithTaxon:
     A mixin that can be used on any entity that can be taxonomically classified. This includes individual organisms;
     genes, their products and other molecular entities; body parts; biological processes
     """
-    in_taxon: Optional[Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]] = field(default_factory=list)
+
+    in_taxon: Optional[
+        Union[List[Union[URIorCURIE, OrganismTaxon]], Union[URIorCURIE, OrganismTaxon]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -2379,14 +2314,11 @@ class GenomicEntity(ThingWithTaxon):
     has_biological_sequence: Optional[Union[str, BiologicalSequence]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class ChemicalSubstance:
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalSubstance"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2398,14 +2330,23 @@ class BiologicalProcessOrActivity(BiologicalEntity, Occurrent, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "BiologicalProcessOrActivity"
-    _id_prefixes: ClassVar[List[str]] = [
-        "GO",
-        "REACT"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT"]
 
-    has_input: Optional[Union[List[Union[URIorCURIE, BiologicalProcessOrActivity]], Union[URIorCURIE, BiologicalProcessOrActivity]]] = field(default_factory=list)
-    has_output: Optional[Union[List[Union[URIorCURIE, BiologicalProcessOrActivity]], Union[URIorCURIE, BiologicalProcessOrActivity]]] = field(default_factory=list)
-    enabled_by: Optional[Union[List[Union[URIorCURIE, PhysicalEntity]], Union[URIorCURIE, PhysicalEntity]]] = field(default_factory=list)
+    has_input: Optional[
+        Union[
+            List[Union[URIorCURIE, BiologicalProcessOrActivity]],
+            Union[URIorCURIE, BiologicalProcessOrActivity],
+        ]
+    ] = field(default_factory=list)
+    has_output: Optional[
+        Union[
+            List[Union[URIorCURIE, BiologicalProcessOrActivity]],
+            Union[URIorCURIE, BiologicalProcessOrActivity],
+        ]
+    ] = field(default_factory=list)
+    enabled_by: Optional[
+        Union[List[Union[URIorCURIE, PhysicalEntity]], Union[URIorCURIE, PhysicalEntity]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -2444,12 +2385,18 @@ class MolecularActivity(BiologicalProcessOrActivity, Occurrent, OntologyClass):
         "UMLS",
         "BIGG.REACTION",
         "SEED.REACTION",
-        "METANETX.REACTION"
+        "METANETX.REACTION",
     ]
 
-    has_input: Optional[Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]] = field(default_factory=list)
-    has_output: Optional[Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]] = field(default_factory=list)
-    enabled_by: Optional[Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]] = field(default_factory=list)
+    has_input: Optional[
+        Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]
+    ] = field(default_factory=list)
+    has_output: Optional[
+        Union[List[Union[URIorCURIE, MolecularEntity]], Union[URIorCURIE, MolecularEntity]]
+    ] = field(default_factory=list)
+    enabled_by: Optional[
+        Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -2474,14 +2421,7 @@ class BiologicalProcess(BiologicalProcessOrActivity, Occurrent, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "BiologicalProcess"
-    _id_prefixes: ClassVar[List[str]] = [
-        "GO",
-        "REACT",
-        "metacyc.reaction",
-        "KEGG.MODULE"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT", "metacyc.reaction", "KEGG.MODULE"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2499,10 +2439,8 @@ class Pathway(BiologicalProcess, OntologyClass):
         "WIKIPATHWAYS",
         "FB",
         "PANTHER.PATHWAY",
-        "KEGG.PATHWAY"
+        "KEGG.PATHWAY",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2510,12 +2448,7 @@ class PhysiologicalProcess(BiologicalProcess, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "PhysiologicalProcess"
-    _id_prefixes: ClassVar[List[str]] = [
-        "GO",
-        "REACT"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["GO", "REACT"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2523,8 +2456,6 @@ class Behavior(BiologicalProcess, ActivityAndBehavior, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Behavior"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2537,8 +2468,6 @@ class OrganismAttribute(Attribute):
     _category: ClassVar[str] = "OrganismAttribute"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PhenotypicQuality(OrganismAttribute):
     """
@@ -2547,8 +2476,6 @@ class PhenotypicQuality(OrganismAttribute):
 
     # Class Variables
     _category: ClassVar[str] = "PhenotypicQuality"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2562,15 +2489,16 @@ class Inheritance(OrganismAttribute):
     _category: ClassVar[str] = "Inheritance"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class OrganismalEntity(BiologicalEntity):
     """
     A named entity that is either a part of an organism, a whole organism, population or clade of organisms, excluding
     chemical entities
     """
-    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(default_factory=list)
+
+    has_attribute: Optional[Union[List[Union[str, Attribute]], Union[str, Attribute]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -2589,8 +2517,6 @@ class LifeStage(OrganismalEntity, ThingWithTaxon):
     _category: ClassVar[str] = "LifeStage"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class IndividualOrganism(OrganismalEntity, ThingWithTaxon):
     """
@@ -2600,11 +2526,7 @@ class IndividualOrganism(OrganismalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "IndividualOrganism"
-    _id_prefixes: ClassVar[List[str]] = [
-        "ORCID"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["ORCID"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2616,11 +2538,7 @@ class PopulationOfIndividualOrganisms(OrganismalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "PopulationOfIndividualOrganisms"
-    _id_prefixes: ClassVar[List[str]] = [
-        "HANCESTRO"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["HANCESTRO"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2633,8 +2551,6 @@ class StudyPopulation(PopulationOfIndividualOrganisms):
     _category: ClassVar[str] = "StudyPopulation"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class DiseaseOrPhenotypicFeature(BiologicalEntity, ThingWithTaxon):
     """
@@ -2644,8 +2560,6 @@ class DiseaseOrPhenotypicFeature(BiologicalEntity, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeature"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2669,10 +2583,8 @@ class Disease(DiseaseOrPhenotypicFeature):
         "ICD9",
         "KEGG.DISEASE",
         "HP",
-        "MP"
+        "MP",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2698,10 +2610,8 @@ class PhenotypicFeature(DiseaseOrPhenotypicFeature):
         "SNOMEDCT",
         "MESH",
         "XPO",
-        "FYPO"
+        "FYPO",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2714,8 +2624,6 @@ class BehavioralFeature(PhenotypicFeature):
     _category: ClassVar[str] = "BehavioralFeature"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class AnatomicalEntity(OrganismalEntity, ThingWithTaxon, PhysicalEssence):
     """
@@ -2724,16 +2632,7 @@ class AnatomicalEntity(OrganismalEntity, ThingWithTaxon, PhysicalEssence):
 
     # Class Variables
     _category: ClassVar[str] = "AnatomicalEntity"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UBERON",
-        "GO",
-        "CL",
-        "UMLS",
-        "MESH",
-        "NCIT"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UBERON", "GO", "CL", "UMLS", "MESH", "NCIT"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2744,17 +2643,7 @@ class CellularComponent(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "CellularComponent"
-    _id_prefixes: ClassVar[List[str]] = [
-        "GO",
-        "MESH",
-        "UMLS",
-        "NCIT",
-        "SNOMEDCT",
-        "CL",
-        "UBERON"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["GO", "MESH", "UMLS", "NCIT", "SNOMEDCT", "CL", "UBERON"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2762,17 +2651,7 @@ class Cell(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Cell"
-    _id_prefixes: ClassVar[List[str]] = [
-        "CL",
-        "PO",
-        "UMLS",
-        "NCIT",
-        "MESH",
-        "UBERON",
-        "SNOMEDCT"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["CL", "PO", "UMLS", "NCIT", "MESH", "UBERON", "SNOMEDCT"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2780,11 +2659,7 @@ class CellLine(OrganismalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "CellLine"
-    _id_prefixes: ClassVar[List[str]] = [
-        "CLO"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["CLO"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2792,16 +2667,7 @@ class GrossAnatomicalStructure(AnatomicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "GrossAnatomicalStructure"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UBERON",
-        "UMLS",
-        "MESH",
-        "NCIT",
-        "PO",
-        "FAO"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UBERON", "UMLS", "MESH", "NCIT", "PO", "FAO"]
 
 
 @dataclass(config=PydanticConfig)
@@ -2811,8 +2677,6 @@ class ChemicalEntityOrGeneOrGeneProduct:
     across chemical entities that must include genes and their children as chemical entities.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class ChemicalEntityOrProteinOrPolypeptide:
@@ -2821,26 +2685,27 @@ class ChemicalEntityOrProteinOrPolypeptide:
     searching across chemical entities that must include genes and their children as chemical entities.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
-class ChemicalEntity(NamedThing, PhysicalEssence, ChemicalOrDrugOrTreatment, ChemicalEntityOrGeneOrGeneProduct, ChemicalEntityOrProteinOrPolypeptide):
+class ChemicalEntity(
+    NamedThing,
+    PhysicalEssence,
+    ChemicalOrDrugOrTreatment,
+    ChemicalEntityOrGeneOrGeneProduct,
+    ChemicalEntityOrProteinOrPolypeptide,
+):
     """
     A chemical entity is a physical entity that pertains to chemistry or biochemistry.
     """
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalEntity"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UNII",
-        "MESH",
-        "CAS",
-        "UMLS"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["UNII", "MESH", "CAS", "UMLS"]
 
     trade_name: Optional[Union[URIorCURIE, ChemicalEntity]] = None
-    available_from: Optional[Union[List[Union[str, DrugAvailabilityEnum]], Union[str, DrugAvailabilityEnum]]] = field(default_factory=list)
+    available_from: Optional[
+        Union[List[Union[str, DrugAvailabilityEnum]], Union[str, DrugAvailabilityEnum]]
+    ] = field(default_factory=list)
     max_tolerated_dose: Optional[Union[str, str]] = None
     is_toxic: Optional[Union[bool, Bool]] = None
 
@@ -2885,11 +2750,10 @@ class MolecularEntity(ChemicalEntity):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
-        "UMLS"
+        "UMLS",
     ]
 
     is_metabolite: Optional[Union[bool, Bool]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -2925,7 +2789,7 @@ class SmallMolecule(MolecularEntity):
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
         "BIGG.METABOLITE",
-        "UMLS"
+        "UMLS",
     ]
 
     id: Union[URIorCURIE, SmallMolecule] = None
@@ -2968,7 +2832,7 @@ class ChemicalMixture(ChemicalEntity):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
-        "UMLS"
+        "UMLS",
     ]
 
     is_supplement: Optional[Union[URIorCURIE, ChemicalMixture]] = None
@@ -3008,10 +2872,8 @@ class NucleicAcidEntity(MolecularEntity, GenomicEntity, PhysicalEssence, Ontolog
         "INCHI",
         "INCHIKEY",
         "KEGG.GLYCAN",
-        "KEGG.ENVIRON"
+        "KEGG.ENVIRON",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3044,10 +2906,8 @@ class MolecularMixture(ChemicalMixture):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
-        "UMLS"
+        "UMLS",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3080,10 +2940,8 @@ class ComplexMolecularMixture(ChemicalMixture):
         "KEGG.DRUG",
         "KEGG.DGROUP",
         "KEGG.ENVIRON",
-        "UMLS"
+        "UMLS",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3095,11 +2953,7 @@ class ProcessedMaterial(ChemicalMixture):
 
     # Class Variables
     _category: ClassVar[str] = "ProcessedMaterial"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UMLS"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UMLS"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3110,13 +2964,7 @@ class Drug(MolecularMixture, ChemicalOrDrugOrTreatment, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Drug"
-    _id_prefixes: ClassVar[List[str]] = [
-        "RXCUI",
-        "NDC",
-        "UMLS"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["RXCUI", "NDC", "UMLS"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3126,15 +2974,11 @@ class EnvironmentalFoodContaminant(ChemicalEntity):
     _category: ClassVar[str] = "EnvironmentalFoodContaminant"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class FoodAdditive(ChemicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "FoodAdditive"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3144,15 +2988,11 @@ class Nutrient(ChemicalEntity):
     _category: ClassVar[str] = "Nutrient"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Macronutrient(Nutrient):
 
     # Class Variables
     _category: ClassVar[str] = "Macronutrient"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3162,15 +3002,11 @@ class Micronutrient(Nutrient):
     _category: ClassVar[str] = "Micronutrient"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Vitamin(Micronutrient):
 
     # Class Variables
     _category: ClassVar[str] = "Vitamin"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3181,11 +3017,7 @@ class Food(ChemicalMixture):
 
     # Class Variables
     _category: ClassVar[str] = "Food"
-    _id_prefixes: ClassVar[List[str]] = [
-        "foodb.compound"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["foodb.compound"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3194,8 +3026,8 @@ class MacromolecularMachineMixin:
     A union of gene locus, gene product, and macromolecular complex mixin. These are the basic units of function in a
     cell. They either carry out individual biological activities, or they encode molecules which do this.
     """
-    name: Optional[Union[str, SymbolType]] = None
 
+    name: Optional[Union[str, SymbolType]] = None
 
 
 @dataclass(config=PydanticConfig)
@@ -3205,16 +3037,18 @@ class GeneOrGeneProduct(MacromolecularMachineMixin):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "CHEMBL.TARGET",
-        "IUPHAR.FAMILY"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["CHEMBL.TARGET", "IUPHAR.FAMILY"]
 
 
 @dataclass(config=PydanticConfig)
-class Gene(BiologicalEntity, GeneOrGeneProduct, GenomicEntity, ChemicalEntityOrGeneOrGeneProduct, PhysicalEssence, OntologyClass):
+class Gene(
+    BiologicalEntity,
+    GeneOrGeneProduct,
+    GenomicEntity,
+    ChemicalEntityOrGeneOrGeneProduct,
+    PhysicalEssence,
+    OntologyClass,
+):
     """
     A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A
     gene locus may include regulatory regions, transcribed regions and/or other functional sequence regions.
@@ -3238,12 +3072,16 @@ class Gene(BiologicalEntity, GeneOrGeneProduct, GenomicEntity, ChemicalEntityOrG
         "OMIM",
         "KEGG.GENE",
         "UMLS",
-        "Xenbase"
+        "Xenbase",
     ]
 
     symbol: Optional[Union[str, str]] = None
-    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(default_factory=list)
-    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
+    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(
+        default_factory=list
+    )
+    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -3264,14 +3102,14 @@ class GeneProductMixin(GeneOrGeneProduct):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "UniProtKB",
-        "gtpo",
-        "PR"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "gtpo", "PR"]
 
-    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(default_factory=list)
-    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(default_factory=list)
+    synonym: Optional[Union[List[Union[str, LabelType]], Union[str, LabelType]]] = field(
+        default_factory=list
+    )
+    xref: Optional[Union[List[Union[str, URIorCURIE]], Union[str, URIorCURIE]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -3292,8 +3130,6 @@ class GeneProductIsoformMixin(GeneProductMixin):
     designation of canonical or reference may be arbitrary, or it may represent the superclass of all isoforms.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class MacromolecularComplexMixin(MacromolecularMachineMixin):
@@ -3303,14 +3139,7 @@ class MacromolecularComplexMixin(MacromolecularMachineMixin):
     """
 
     # Class Variables
-    _id_prefixes: ClassVar[List[str]] = [
-        "INTACT",
-        "GO",
-        "PR",
-        "REACT"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["INTACT", "GO", "PR", "REACT"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3321,8 +3150,6 @@ class Genome(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Genome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3336,8 +3163,6 @@ class Exon(NucleicAcidEntity):
     _category: ClassVar[str] = "Exon"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Transcript(NucleicAcidEntity):
     """
@@ -3346,12 +3171,7 @@ class Transcript(NucleicAcidEntity):
 
     # Class Variables
     _category: ClassVar[str] = "Transcript"
-    _id_prefixes: ClassVar[List[str]] = [
-        "ENSEMBL",
-        "FB"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["ENSEMBL", "FB"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3361,10 +3181,13 @@ class CodingSequence(NucleicAcidEntity):
     _category: ClassVar[str] = "CodingSequence"
 
 
-
-
 @dataclass(config=PydanticConfig)
-class Polypeptide(BiologicalEntity, ThingWithTaxon, ChemicalEntityOrGeneOrGeneProduct, ChemicalEntityOrProteinOrPolypeptide):
+class Polypeptide(
+    BiologicalEntity,
+    ThingWithTaxon,
+    ChemicalEntityOrGeneOrGeneProduct,
+    ChemicalEntityOrProteinOrPolypeptide,
+):
     """
     A polypeptide is a molecular entity characterized by availability in protein databases of amino-acid-based
     sequence representations of its precise primary structure; for convenience of representation, partial sequences of
@@ -3373,15 +3196,7 @@ class Polypeptide(BiologicalEntity, ThingWithTaxon, ChemicalEntityOrGeneOrGenePr
 
     # Class Variables
     _category: ClassVar[str] = "Polypeptide"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UniProtKB",
-        "PR",
-        "ENSEMBL",
-        "FB",
-        "UMLS"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "PR", "ENSEMBL", "FB", "UMLS"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3393,16 +3208,7 @@ class Protein(Polypeptide, GeneProductMixin, ThingWithTaxon):
 
     # Class Variables
     _category: ClassVar[str] = "Protein"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UniProtKB",
-        "PR",
-        "ENSEMBL",
-        "FB",
-        "UMLS",
-        "MESH"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "PR", "ENSEMBL", "FB", "UMLS", "MESH"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3414,14 +3220,7 @@ class ProteinIsoform(Protein, GeneProductIsoformMixin):
 
     # Class Variables
     _category: ClassVar[str] = "ProteinIsoform"
-    _id_prefixes: ClassVar[List[str]] = [
-        "UniProtKB",
-        "UNIPROT.ISOFORM",
-        "PR",
-        "ENSEMBL"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["UniProtKB", "UNIPROT.ISOFORM", "PR", "ENSEMBL"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3435,18 +3234,12 @@ class NucleicAcidSequenceMotif(BiologicalEntity):
     _category: ClassVar[str] = "NucleicAcidSequenceMotif"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class RNAProduct(Transcript, GeneProductMixin):
 
     # Class Variables
     _category: ClassVar[str] = "RNAProduct"
-    _id_prefixes: ClassVar[List[str]] = [
-        "RNACENTRAL"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3457,11 +3250,7 @@ class RNAProductIsoform(RNAProduct, GeneProductIsoformMixin):
 
     # Class Variables
     _category: ClassVar[str] = "RNAProductIsoform"
-    _id_prefixes: ClassVar[List[str]] = [
-        "RNACENTRAL"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3469,13 +3258,7 @@ class NoncodingRNAProduct(RNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "NoncodingRNAProduct"
-    _id_prefixes: ClassVar[List[str]] = [
-        "RNACENTRAL",
-        "NCBIGene",
-        "ENSEMBL"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["RNACENTRAL", "NCBIGene", "ENSEMBL"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3483,13 +3266,7 @@ class MicroRNA(NoncodingRNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "MicroRNA"
-    _id_prefixes: ClassVar[List[str]] = [
-        "MIR",
-        "HGNC",
-        "WormBase"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["MIR", "HGNC", "WormBase"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3502,13 +3279,7 @@ class SiRNA(NoncodingRNAProduct):
 
     # Class Variables
     _category: ClassVar[str] = "SiRNA"
-    _id_prefixes: ClassVar[List[str]] = [
-        "MIR",
-        "HGNC",
-        "WormBase"
-    ]
-
-
+    _id_prefixes: ClassVar[List[str]] = ["MIR", "HGNC", "WormBase"]
 
 
 @dataclass(config=PydanticConfig)
@@ -3516,7 +3287,10 @@ class GeneGroupingMixin:
     """
     any grouping of multiple genes or gene products
     """
-    has_gene_or_gene_product: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(default_factory=list)
+
+    has_gene_or_gene_product: Optional[
+        Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -3537,15 +3311,11 @@ class ProteinDomain(BiologicalEntity, GeneGroupingMixin, ChemicalEntityOrGeneOrG
     _category: ClassVar[str] = "ProteinDomain"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ProteinFamily(BiologicalEntity, GeneGroupingMixin, ChemicalEntityOrGeneOrGeneProduct):
 
     # Class Variables
     _category: ClassVar[str] = "ProteinFamily"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3576,10 +3346,8 @@ class GeneFamily(BiologicalEntity, GeneGroupingMixin, ChemicalEntityOrGeneOrGene
         "RFAM",
         "KEGG.ORTHOLOGY",
         "EGGNOG",
-        "COG"
+        "COG",
     ]
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3587,8 +3355,6 @@ class Zygosity(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "Zygosity"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3600,13 +3366,9 @@ class Genotype(BiologicalEntity, PhysicalEssence, GenomicEntity, OntologyClass):
 
     # Class Variables
     _category: ClassVar[str] = "Genotype"
-    _id_prefixes: ClassVar[List[str]] = [
-        "ZFIN",
-        "FB"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["ZFIN", "FB"]
 
     has_zygosity: Optional[Union[str, Zygosity]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3617,8 +3379,6 @@ class Haplotype(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass)
 
     # Class Variables
     _category: ClassVar[str] = "Haplotype"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3639,11 +3399,13 @@ class SequenceVariant(BiologicalEntity, GenomicEntity, PhysicalEssence, Ontology
         "ZFIN",
         "FB",
         "WB",
-        "WormBase"
+        "WormBase",
     ]
 
     id: Union[URIorCURIE, SequenceVariant] = None
-    has_gene: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(default_factory=list)
+    has_gene: Optional[Union[List[Union[URIorCURIE, Gene]], Union[URIorCURIE, Gene]]] = field(
+        default_factory=list
+    )
     has_biological_sequence: Optional[Union[str, BiologicalSequence]] = None
 
     # Validators
@@ -3669,8 +3431,6 @@ class Snv(SequenceVariant):
     _category: ClassVar[str] = "Snv"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ReagentTargetedGene(BiologicalEntity, GenomicEntity, PhysicalEssence, OntologyClass):
     """
@@ -3682,8 +3442,6 @@ class ReagentTargetedGene(BiologicalEntity, GenomicEntity, PhysicalEssence, Onto
     _category: ClassVar[str] = "ReagentTargetedGene"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ClinicalAttribute(Attribute):
     """
@@ -3692,8 +3450,6 @@ class ClinicalAttribute(Attribute):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalAttribute"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3727,8 +3483,6 @@ class ClinicalModifier(ClinicalAttribute):
     _category: ClassVar[str] = "ClinicalModifier"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ClinicalCourse(ClinicalAttribute):
     """
@@ -3740,8 +3494,6 @@ class ClinicalCourse(ClinicalAttribute):
     _category: ClassVar[str] = "ClinicalCourse"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Onset(ClinicalCourse):
     """
@@ -3750,8 +3502,6 @@ class Onset(ClinicalCourse):
 
     # Class Variables
     _category: ClassVar[str] = "Onset"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3765,8 +3515,6 @@ class ClinicalEntity(NamedThing):
     _category: ClassVar[str] = "ClinicalEntity"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ClinicalTrial(ClinicalEntity):
 
@@ -3774,15 +3522,11 @@ class ClinicalTrial(ClinicalEntity):
     _category: ClassVar[str] = "ClinicalTrial"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ClinicalIntervention(ClinicalEntity):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalIntervention"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3794,13 +3538,11 @@ class ClinicalFinding(PhenotypicFeature):
 
     # Class Variables
     _category: ClassVar[str] = "ClinicalFinding"
-    _id_prefixes: ClassVar[List[str]] = [
-        "LOINC",
-        "NCIT",
-        "EFO"
-    ]
+    _id_prefixes: ClassVar[List[str]] = ["LOINC", "NCIT", "EFO"]
 
-    has_attribute: Optional[Union[List[Union[str, ClinicalAttribute]], Union[str, ClinicalAttribute]]] = field(default_factory=list)
+    has_attribute: Optional[
+        Union[List[Union[str, ClinicalAttribute]], Union[str, ClinicalAttribute]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -3816,8 +3558,6 @@ class Hospitalization(ClinicalIntervention):
     _category: ClassVar[str] = "Hospitalization"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class SocioeconomicAttribute(Attribute):
     """
@@ -3828,8 +3568,6 @@ class SocioeconomicAttribute(Attribute):
     _category: ClassVar[str] = "SocioeconomicAttribute"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Case(IndividualOrganism):
     """
@@ -3838,8 +3576,6 @@ class Case(IndividualOrganism):
 
     # Class Variables
     _category: ClassVar[str] = "Case"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3853,20 +3589,20 @@ class Cohort(StudyPopulation):
     _category: ClassVar[str] = "Cohort"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ExposureEvent:
     """
     A (possibly time bounded) incidence of a feature of the environment of an organism that influences one or more
     phenotypic features of that organism, potentially mediated by genes
     """
+
     timepoint: Optional[Union[str, TimeType]] = None
 
 
-
 @dataclass(config=PydanticConfig)
-class GenomicBackgroundExposure(ExposureEvent, GeneGroupingMixin, PhysicalEssence, GenomicEntity, OntologyClass):
+class GenomicBackgroundExposure(
+    ExposureEvent, GeneGroupingMixin, PhysicalEssence, GenomicEntity, OntologyClass
+):
     """
     A genomic background exposure is where an individual's specific genomic background of genes, sequence variants or
     other pre-existing genomic conditions constitute a kind of 'exposure' to the organism, leading to or influencing
@@ -3877,15 +3613,11 @@ class GenomicBackgroundExposure(ExposureEvent, GeneGroupingMixin, PhysicalEssenc
     _category: ClassVar[str] = "GenomicBackgroundExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PathologicalEntityMixin:
     """
     A pathological (abnormal) structure or process.
     """
-
-    pass
 
 
 @dataclass(config=PydanticConfig)
@@ -3899,8 +3631,6 @@ class PathologicalProcess(BiologicalProcess, PathologicalEntityMixin):
     _category: ClassVar[str] = "PathologicalProcess"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PathologicalProcessExposure(ExposureEvent):
     """
@@ -3910,8 +3640,6 @@ class PathologicalProcessExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalProcessExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3925,8 +3653,6 @@ class PathologicalAnatomicalStructure(AnatomicalEntity, PathologicalEntityMixin)
     _category: ClassVar[str] = "PathologicalAnatomicalStructure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PathologicalAnatomicalExposure(ExposureEvent):
     """
@@ -3936,8 +3662,6 @@ class PathologicalAnatomicalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalAnatomicalExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3952,8 +3676,6 @@ class DiseaseOrPhenotypicFeatureExposure(ExposureEvent, PathologicalEntityMixin)
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeatureExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class ChemicalExposure(ExposureEvent):
     """
@@ -3962,8 +3684,6 @@ class ChemicalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "ChemicalExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -3976,8 +3696,6 @@ class ComplexChemicalExposure:
     _category: ClassVar[str] = "ComplexChemicalExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class DrugExposure(ChemicalExposure, ExposureEvent):
     """
@@ -3986,8 +3704,6 @@ class DrugExposure(ChemicalExposure, ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "DrugExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4001,8 +3717,6 @@ class DrugToGeneInteractionExposure(DrugExposure, GeneGroupingMixin):
     _category: ClassVar[str] = "DrugToGeneInteractionExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class Treatment(NamedThing, ExposureEvent, ChemicalOrDrugOrTreatment):
     """
@@ -4013,9 +3727,15 @@ class Treatment(NamedThing, ExposureEvent, ChemicalOrDrugOrTreatment):
     # Class Variables
     _category: ClassVar[str] = "Treatment"
 
-    has_drug: Optional[Union[List[Union[URIorCURIE, Drug]], Union[URIorCURIE, Drug]]] = field(default_factory=list)
-    has_device: Optional[Union[List[Union[URIorCURIE, Device]], Union[URIorCURIE, Device]]] = field(default_factory=list)
-    has_procedure: Optional[Union[List[Union[URIorCURIE, Procedure]], Union[URIorCURIE, Procedure]]] = field(default_factory=list)
+    has_drug: Optional[Union[List[Union[URIorCURIE, Drug]], Union[URIorCURIE, Drug]]] = field(
+        default_factory=list
+    )
+    has_device: Optional[Union[List[Union[URIorCURIE, Device]], Union[URIorCURIE, Device]]] = field(
+        default_factory=list
+    )
+    has_procedure: Optional[
+        Union[List[Union[URIorCURIE, Procedure]], Union[URIorCURIE, Procedure]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -4042,8 +3762,6 @@ class BioticExposure(ExposureEvent):
     _category: ClassVar[str] = "BioticExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EnvironmentalExposure(ExposureEvent):
     """
@@ -4053,8 +3771,6 @@ class EnvironmentalExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "EnvironmentalExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4067,8 +3783,6 @@ class GeographicExposure(EnvironmentalExposure, ExposureEvent):
     _category: ClassVar[str] = "GeographicExposure"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class BehavioralExposure(ExposureEvent):
     """
@@ -4077,8 +3791,6 @@ class BehavioralExposure(ExposureEvent):
 
     # Class Variables
     _category: ClassVar[str] = "BehavioralExposure"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4091,7 +3803,9 @@ class SocioeconomicExposure(ExposureEvent):
     # Class Variables
     _category: ClassVar[str] = "SocioeconomicExposure"
 
-    has_attribute: Union[List[Union[str, SocioeconomicAttribute]], Union[str, SocioeconomicAttribute]] = None
+    has_attribute: Union[
+        List[Union[str, SocioeconomicAttribute]], Union[str, SocioeconomicAttribute]
+    ] = None
 
     # Validators
 
@@ -4109,8 +3823,6 @@ class Outcome:
     various categories of possible biological or non-biological (e.g. clinical) outcomes.
     """
 
-    pass
-
 
 @dataclass(config=PydanticConfig)
 class PathologicalProcessOutcome(Outcome):
@@ -4122,8 +3834,6 @@ class PathologicalProcessOutcome(Outcome):
     _category: ClassVar[str] = "PathologicalProcessOutcome"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class PathologicalAnatomicalOutcome(Outcome):
     """
@@ -4132,8 +3842,6 @@ class PathologicalAnatomicalOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "PathologicalAnatomicalOutcome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4147,8 +3855,6 @@ class DiseaseOrPhenotypicFeatureOutcome(Outcome):
     _category: ClassVar[str] = "DiseaseOrPhenotypicFeatureOutcome"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class BehavioralOutcome(Outcome):
     """
@@ -4157,8 +3863,6 @@ class BehavioralOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "BehavioralOutcome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4172,8 +3876,6 @@ class HospitalizationOutcome(Outcome):
     _category: ClassVar[str] = "HospitalizationOutcome"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class MortalityOutcome(Outcome):
     """
@@ -4182,8 +3884,6 @@ class MortalityOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "MortalityOutcome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4196,8 +3896,6 @@ class EpidemiologicalOutcome(Outcome):
     _category: ClassVar[str] = "EpidemiologicalOutcome"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class SocioeconomicOutcome(Outcome):
     """
@@ -4207,8 +3905,6 @@ class SocioeconomicOutcome(Outcome):
 
     # Class Variables
     _category: ClassVar[str] = "SocioeconomicOutcome"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4225,11 +3921,19 @@ class Association(Entity):
     object: Union[URIorCURIE, NamedThing] = None
     relation: Optional[Union[str, str]] = None
     negated: Optional[Union[bool, Bool]] = None
-    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(default_factory=list)
-    publications: Optional[Union[List[Union[URIorCURIE, Publication]], Union[URIorCURIE, Publication]]] = field(default_factory=list)
-    has_evidence: Optional[Union[List[Union[URIorCURIE, EvidenceType]], Union[URIorCURIE, EvidenceType]]] = field(default_factory=list)
+    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(
+        default_factory=list
+    )
+    publications: Optional[
+        Union[List[Union[URIorCURIE, Publication]], Union[URIorCURIE, Publication]]
+    ] = field(default_factory=list)
+    has_evidence: Optional[
+        Union[List[Union[URIorCURIE, EvidenceType]], Union[URIorCURIE, EvidenceType]]
+    ] = field(default_factory=list)
     type: Optional[Union[str, str]] = None
-    category: Optional[Union[List[Union[str, CategoryType]], Union[str, CategoryType]]] = field(default_factory=list)
+    category: Optional[Union[List[Union[str, CategoryType]], Union[str, CategoryType]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -4275,7 +3979,9 @@ class ContributorAssociation(Association):
     subject: Union[URIorCURIE, InformationContentEntity] = None
     predicate: Union[str, PredicateType] = None
     object: Union[URIorCURIE, Agent] = None
-    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(default_factory=list)
+    qualifiers: Optional[Union[List[Union[str, OntologyClass]], Union[str, OntologyClass]]] = field(
+        default_factory=list
+    )
 
     # Validators
 
@@ -4407,6 +4113,7 @@ class GeneToGeneAssociation(Association):
     abstract parent class for different kinds of gene-gene or gene product to gene product relationships. Includes
     homology and interaction.
     """
+
     subject: Union[str, GeneOrGeneProduct] = None
     object: Union[str, GeneOrGeneProduct] = None
 
@@ -4449,6 +4156,7 @@ class GeneExpressionMixin:
     Observed gene expression intensity, context (site, stage) and associated phenotypic status within which the
     expression occurs.
     """
+
     quantifier_qualifier: Optional[Union[str, OntologyClass]] = None
     expression_site: Optional[Union[URIorCURIE, AnatomicalEntity]] = None
     stage_qualifier: Optional[Union[URIorCURIE, LifeStage]] = None
@@ -4557,6 +4265,7 @@ class CellLineToEntityAssociationMixin:
     """
     An relationship between a cell line and another entity
     """
+
     subject: Union[URIorCURIE, CellLine] = None
 
     # Validators
@@ -4573,6 +4282,7 @@ class ChemicalEntityToEntityAssociationMixin:
     """
     An interaction between a chemical entity and another entity
     """
+
     subject: Union[str, ChemicalEntityOrGeneOrGeneProduct] = None
 
     # Validators
@@ -4588,6 +4298,7 @@ class DrugToEntityAssociationMixin(ChemicalEntityToEntityAssociationMixin):
     """
     An interaction between a drug and another entity
     """
+
     subject: Union[URIorCURIE, Drug] = None
 
     # Validators
@@ -4604,6 +4315,7 @@ class ChemicalToEntityAssociationMixin(ChemicalEntityToEntityAssociationMixin):
     """
     An interaction between a chemical entity and another entity
     """
+
     subject: Union[str, ChemicalEntityOrGeneOrGeneProduct] = None
 
     # Validators
@@ -4619,6 +4331,7 @@ class CaseToEntityAssociationMixin:
     """
     An abstract association for use where the case is the subject
     """
+
     subject: Union[URIorCURIE, Case] = None
 
     # Validators
@@ -4707,7 +4420,9 @@ class ChemicalToChemicalDerivationAssociation(ChemicalToChemicalAssociation):
     subject: Union[URIorCURIE, ChemicalEntity] = None
     object: Union[URIorCURIE, ChemicalEntity] = None
     predicate: Union[str, PredicateType] = None
-    catalyst_qualifier: Optional[Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]] = field(default_factory=list)
+    catalyst_qualifier: Optional[
+        Union[List[Union[str, MacromolecularMachineMixin]], Union[str, MacromolecularMachineMixin]]
+    ] = field(default_factory=list)
 
     # Validators
 
@@ -4796,6 +4511,7 @@ class MaterialSampleToEntityAssociationMixin:
     """
     An association between a material sample and something.
     """
+
     subject: Union[URIorCURIE, MaterialSample] = None
 
     # Validators
@@ -4858,6 +4574,7 @@ class EntityToExposureEventAssociationMixin:
     """
     An association between some entity and an exposure event.
     """
+
     object: Union[str, ExposureEvent] = None
 
     # Validators
@@ -4869,15 +4586,15 @@ class EntityToExposureEventAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseToExposureEventAssociation(Association, DiseaseToEntityAssociationMixin, EntityToExposureEventAssociationMixin):
+class DiseaseToExposureEventAssociation(
+    Association, DiseaseToEntityAssociationMixin, EntityToExposureEventAssociationMixin
+):
     """
     An association between an exposure event and a disease.
     """
 
     # Class Variables
     _category: ClassVar[str] = "DiseaseToExposureEventAssociation"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -4887,13 +4604,12 @@ class ExposureEventToEntityAssociationMixin:
     _category: ClassVar[str] = "ExposureEventToEntityAssociationMixin"
 
 
-
-
 @dataclass(config=PydanticConfig)
 class EntityToOutcomeAssociationMixin:
     """
     An association between some entity and an outcome
     """
+
     object: Union[str, Outcome] = None
 
     # Validators
@@ -4905,7 +4621,9 @@ class EntityToOutcomeAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class ExposureEventToOutcomeAssociation(Association, ExposureEventToEntityAssociationMixin, EntityToOutcomeAssociationMixin):
+class ExposureEventToOutcomeAssociation(
+    Association, ExposureEventToEntityAssociationMixin, EntityToOutcomeAssociationMixin
+):
     """
     An association between an exposure event and an outcome.
     """
@@ -4929,8 +4647,8 @@ class FrequencyQualifierMixin:
     """
     Qualifier for frequency type associations
     """
-    frequency_qualifier: Optional[Union[str, FrequencyValue]] = None
 
+    frequency_qualifier: Optional[Union[str, FrequencyValue]] = None
 
 
 @dataclass(config=PydanticConfig)
@@ -4938,9 +4656,9 @@ class EntityToFeatureOrDiseaseQualifiersMixin(FrequencyQualifierMixin):
     """
     Qualifiers for entity to disease or phenotype associations.
     """
+
     severity_qualifier: Optional[Union[str, SeverityValue]] = None
     onset_qualifier: Optional[Union[str, Onset]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -5000,6 +4718,7 @@ class EntityToDiseaseAssociationMixin(EntityToFeatureOrDiseaseQualifiersMixin):
     """
     mixin class for any association whose object (target node) is a disease
     """
+
     object: Union[URIorCURIE, Disease] = None
 
     # Validators
@@ -5025,7 +4744,9 @@ class DiseaseOrPhenotypicFeatureToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseOrPhenotypicFeatureToLocationAssociation(Association, DiseaseOrPhenotypicFeatureToEntityAssociationMixin):
+class DiseaseOrPhenotypicFeatureToLocationAssociation(
+    Association, DiseaseOrPhenotypicFeatureToEntityAssociationMixin
+):
     """
     An association between either a disease or a phenotypic feature and an anatomical entity, where the
     disease/feature manifests in that site.
@@ -5059,7 +4780,11 @@ class EntityToDiseaseOrPhenotypicFeatureAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class CellLineToDiseaseOrPhenotypicFeatureAssociation(Association, CellLineToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
+class CellLineToDiseaseOrPhenotypicFeatureAssociation(
+    Association,
+    CellLineToEntityAssociationMixin,
+    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
+):
     """
     An relationship between a cell line and a disease or a phenotype, where the cell line is derived from an
     individual with that disease or phenotype.
@@ -5080,7 +4805,11 @@ class CellLineToDiseaseOrPhenotypicFeatureAssociation(Association, CellLineToEnt
 
 
 @dataclass(config=PydanticConfig)
-class ChemicalToDiseaseOrPhenotypicFeatureAssociation(Association, ChemicalToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
+class ChemicalToDiseaseOrPhenotypicFeatureAssociation(
+    Association,
+    ChemicalToEntityAssociationMixin,
+    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
+):
     """
     An interaction between a chemical entity and a phenotype or disease, where the presence of the chemical gives rise
     to or exacerbates the phenotype.
@@ -5101,15 +4830,17 @@ class ChemicalToDiseaseOrPhenotypicFeatureAssociation(Association, ChemicalToEnt
 
 
 @dataclass(config=PydanticConfig)
-class MaterialSampleToDiseaseOrPhenotypicFeatureAssociation(Association, MaterialSampleToEntityAssociationMixin, EntityToDiseaseOrPhenotypicFeatureAssociationMixin):
+class MaterialSampleToDiseaseOrPhenotypicFeatureAssociation(
+    Association,
+    MaterialSampleToEntityAssociationMixin,
+    EntityToDiseaseOrPhenotypicFeatureAssociationMixin,
+):
     """
     An association between a material sample and a disease or phenotype.
     """
 
     # Class Variables
     _category: ClassVar[str] = "MaterialSampleToDiseaseOrPhenotypicFeatureAssociation"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -5126,7 +4857,9 @@ class GenotypeToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, GenotypeToEntityAssociationMixin):
+class GenotypeToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin, GenotypeToEntityAssociationMixin
+):
     """
     Any association between one genotype and a phenotypic feature, where having the genotype confers the phenotype,
     either in isolation or through environment
@@ -5153,7 +4886,9 @@ class GenotypeToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeat
 
 
 @dataclass(config=PydanticConfig)
-class ExposureEventToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin):
+class ExposureEventToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin
+):
     """
     Any association between an environment and a phenotypic feature, where being in the environment influences the
     phenotype.
@@ -5173,7 +4908,9 @@ class ExposureEventToPhenotypicFeatureAssociation(Association, EntityToPhenotypi
 
 
 @dataclass(config=PydanticConfig)
-class DiseaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, DiseaseToEntityAssociationMixin):
+class DiseaseToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin, DiseaseToEntityAssociationMixin
+):
     """
     An association between a disease and a phenotypic feature in which the phenotypic feature is associated with the
     disease in some way.
@@ -5183,10 +4920,10 @@ class DiseaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatu
     _category: ClassVar[str] = "DiseaseToPhenotypicFeatureAssociation"
 
 
-
-
 @dataclass(config=PydanticConfig)
-class CaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, CaseToEntityAssociationMixin):
+class CaseToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin, CaseToEntityAssociationMixin
+):
     """
     An association between a case (e.g. individual patient) and a phenotypic feature in which the individual has or
     has had the phenotype.
@@ -5196,10 +4933,10 @@ class CaseToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureA
     _category: ClassVar[str] = "CaseToPhenotypicFeatureAssociation"
 
 
-
-
 @dataclass(config=PydanticConfig)
-class BehaviorToBehavioralFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin):
+class BehaviorToBehavioralFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin
+):
     """
     An association between an mixture behavior and a behavioral feature manifested by the individual exhibited or has
     exhibited the behavior.
@@ -5252,7 +4989,9 @@ class VariantToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GeneToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureAssociationMixin, GeneToEntityAssociationMixin):
+class GeneToPhenotypicFeatureAssociation(
+    Association, EntityToPhenotypicFeatureAssociationMixin, GeneToEntityAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GeneToPhenotypicFeatureAssociation"
@@ -5268,7 +5007,9 @@ class GeneToPhenotypicFeatureAssociation(Association, EntityToPhenotypicFeatureA
 
 
 @dataclass(config=PydanticConfig)
-class GeneToDiseaseAssociation(Association, EntityToDiseaseAssociationMixin, GeneToEntityAssociationMixin):
+class GeneToDiseaseAssociation(
+    Association, EntityToDiseaseAssociationMixin, GeneToEntityAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GeneToDiseaseAssociation"
@@ -5330,7 +5071,9 @@ class VariantToGeneExpressionAssociation(VariantToGeneAssociation, GeneExpressio
 
 
 @dataclass(config=PydanticConfig)
-class VariantToPopulationAssociation(Association, VariantToEntityAssociationMixin, FrequencyQuantifier, FrequencyQualifierMixin):
+class VariantToPopulationAssociation(
+    Association, VariantToEntityAssociationMixin, FrequencyQuantifier, FrequencyQualifierMixin
+):
     """
     An association between a variant and a population, where the variant has particular frequency in the population
     """
@@ -5393,7 +5136,9 @@ class PopulationToPopulationAssociation(Association):
 
 
 @dataclass(config=PydanticConfig)
-class VariantToPhenotypicFeatureAssociation(Association, VariantToEntityAssociationMixin, EntityToPhenotypicFeatureAssociationMixin):
+class VariantToPhenotypicFeatureAssociation(
+    Association, VariantToEntityAssociationMixin, EntityToPhenotypicFeatureAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "VariantToPhenotypicFeatureAssociation"
@@ -5410,7 +5155,9 @@ class VariantToPhenotypicFeatureAssociation(Association, VariantToEntityAssociat
 
 
 @dataclass(config=PydanticConfig)
-class VariantToDiseaseAssociation(Association, VariantToEntityAssociationMixin, EntityToDiseaseAssociationMixin):
+class VariantToDiseaseAssociation(
+    Association, VariantToEntityAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "VariantToDiseaseAssociation"
@@ -5440,7 +5187,9 @@ class VariantToDiseaseAssociation(Association, VariantToEntityAssociationMixin, 
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeToDiseaseAssociation(Association, GenotypeToEntityAssociationMixin, EntityToDiseaseAssociationMixin):
+class GenotypeToDiseaseAssociation(
+    Association, GenotypeToEntityAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GenotypeToDiseaseAssociation"
@@ -5476,6 +5225,7 @@ class ModelToDiseaseAssociationMixin:
     that it recapitulates some features of the disease in a way that is useful for studying the disease outside a
     patient carrying the disease
     """
+
     subject: Union[URIorCURIE, NamedThing] = None
     predicate: Union[str, PredicateType] = None
 
@@ -5494,7 +5244,9 @@ class ModelToDiseaseAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class GeneAsAModelOfDiseaseAssociation(GeneToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class GeneAsAModelOfDiseaseAssociation(
+    GeneToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GeneAsAModelOfDiseaseAssociation"
@@ -5510,7 +5262,9 @@ class GeneAsAModelOfDiseaseAssociation(GeneToDiseaseAssociation, ModelToDiseaseA
 
 
 @dataclass(config=PydanticConfig)
-class VariantAsAModelOfDiseaseAssociation(VariantToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class VariantAsAModelOfDiseaseAssociation(
+    VariantToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "VariantAsAModelOfDiseaseAssociation"
@@ -5527,7 +5281,9 @@ class VariantAsAModelOfDiseaseAssociation(VariantToDiseaseAssociation, ModelToDi
 
 
 @dataclass(config=PydanticConfig)
-class GenotypeAsAModelOfDiseaseAssociation(GenotypeToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class GenotypeAsAModelOfDiseaseAssociation(
+    GenotypeToDiseaseAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "GenotypeAsAModelOfDiseaseAssociation"
@@ -5544,7 +5300,11 @@ class GenotypeAsAModelOfDiseaseAssociation(GenotypeToDiseaseAssociation, ModelTo
 
 
 @dataclass(config=PydanticConfig)
-class CellLineAsAModelOfDiseaseAssociation(CellLineToDiseaseOrPhenotypicFeatureAssociation, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class CellLineAsAModelOfDiseaseAssociation(
+    CellLineToDiseaseOrPhenotypicFeatureAssociation,
+    ModelToDiseaseAssociationMixin,
+    EntityToDiseaseAssociationMixin,
+):
 
     # Class Variables
     _category: ClassVar[str] = "CellLineAsAModelOfDiseaseAssociation"
@@ -5561,7 +5321,9 @@ class CellLineAsAModelOfDiseaseAssociation(CellLineToDiseaseOrPhenotypicFeatureA
 
 
 @dataclass(config=PydanticConfig)
-class OrganismalEntityAsAModelOfDiseaseAssociation(Association, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin):
+class OrganismalEntityAsAModelOfDiseaseAssociation(
+    Association, ModelToDiseaseAssociationMixin, EntityToDiseaseAssociationMixin
+):
 
     # Class Variables
     _category: ClassVar[str] = "OrganismalEntityAsAModelOfDiseaseAssociation"
@@ -5692,6 +5454,7 @@ class SequenceVariantModulatesTreatmentAssociation(Association):
     An association between a sequence variant and a treatment or health intervention. The treatment object itself
     encompasses both the disease and the drug used.
     """
+
     subject: Union[URIorCURIE, SequenceVariant] = None
     object: Union[URIorCURIE, Treatment] = None
 
@@ -5741,6 +5504,7 @@ class MacromolecularMachineToEntityAssociationMixin:
     """
     an association which has a macromolecular machine mixin as a subject
     """
+
     subject: Union[URIorCURIE, NamedThing] = None
 
     # Validators
@@ -5753,7 +5517,9 @@ class MacromolecularMachineToEntityAssociationMixin:
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToMolecularActivityAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
+class MacromolecularMachineToMolecularActivityAssociation(
+    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
+):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a molecular activity
     (as represented in the GO molecular function branch), where the entity carries out the activity, or contributes to
@@ -5775,7 +5541,9 @@ class MacromolecularMachineToMolecularActivityAssociation(FunctionalAssociation,
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToBiologicalProcessAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
+class MacromolecularMachineToBiologicalProcessAssociation(
+    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
+):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a biological process
     or pathway (as represented in the GO biological process branch), where the entity carries out some part of the
@@ -5797,7 +5565,9 @@ class MacromolecularMachineToBiologicalProcessAssociation(FunctionalAssociation,
 
 
 @dataclass(config=PydanticConfig)
-class MacromolecularMachineToCellularComponentAssociation(FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin):
+class MacromolecularMachineToCellularComponentAssociation(
+    FunctionalAssociation, MacromolecularMachineToEntityAssociationMixin
+):
     """
     A functional association between a macromolecular machine (gene, gene product or complex) and a cellular component
     (as represented in the GO cellular component branch), where the entity carries out its function in the cellular
@@ -5906,7 +5676,6 @@ class EntityToDiseaseAssociation(Association):
     FDA_approval_status: Optional[Union[str, FDAApprovalStatusEnum]] = None
 
 
-
 @dataclass(config=PydanticConfig)
 class EntityToPhenotypicFeatureAssociation(Association):
 
@@ -5914,7 +5683,6 @@ class EntityToPhenotypicFeatureAssociation(Association):
     _category: ClassVar[str] = "EntityToPhenotypicFeatureAssociation"
 
     FDA_approval_status: Optional[Union[str, FDAApprovalStatusEnum]] = None
-
 
 
 @dataclass(config=PydanticConfig)
@@ -5925,8 +5693,6 @@ class SequenceAssociation(Association):
 
     # Class Variables
     _category: ClassVar[str] = "SequenceAssociation"
-
-
 
 
 @dataclass(config=PydanticConfig)
@@ -6133,7 +5899,9 @@ class AnatomicalEntityToAnatomicalEntityAssociation(Association):
 
 
 @dataclass(config=PydanticConfig)
-class AnatomicalEntityToAnatomicalEntityPartOfAssociation(AnatomicalEntityToAnatomicalEntityAssociation):
+class AnatomicalEntityToAnatomicalEntityPartOfAssociation(
+    AnatomicalEntityToAnatomicalEntityAssociation
+):
     """
     A relationship between two anatomical entities where the relationship is mereological, i.e the two entities are
     related by parthood. This includes relationships between cellular components and cells, between cells and tissues,
@@ -6168,7 +5936,9 @@ class AnatomicalEntityToAnatomicalEntityPartOfAssociation(AnatomicalEntityToAnat
 
 
 @dataclass(config=PydanticConfig)
-class AnatomicalEntityToAnatomicalEntityOntogenicAssociation(AnatomicalEntityToAnatomicalEntityAssociation):
+class AnatomicalEntityToAnatomicalEntityOntogenicAssociation(
+    AnatomicalEntityToAnatomicalEntityAssociation
+):
     """
     A relationship between two anatomical entities where the relationship is ontogenic, i.e. the two entities are
     related by development. A number of different relationship types can be used to specify the precise nature of the
@@ -6207,6 +5977,7 @@ class OrganismTaxonToEntityAssociation:
     """
     An association between an organism taxon and another entity
     """
+
     subject: Union[URIorCURIE, OrganismTaxon] = None
 
     # Validators
@@ -6223,6 +5994,7 @@ class OrganismTaxonToOrganismTaxonAssociation(Association, OrganismTaxonToEntity
     """
     A relationship between two organism taxon nodes
     """
+
     subject: Union[URIorCURIE, OrganismTaxon] = None
     object: Union[URIorCURIE, OrganismTaxon] = None
 

--- a/pydanticgen/pydanticgen.py
+++ b/pydanticgen/pydanticgen.py
@@ -71,7 +71,9 @@ class PydanticGen(PythonGenerator):
 
     generatorname = Path(__file__).name
     generatorversion = PYTHON_GEN_VERSION
-    curie_regexp = r'^[a-zA-Z_]?[a-zA-Z_0-9.-]*:([A-Za-z0-9_][A-Za-z0-9_.-]*[A-Za-z0-9./\(\)\-><_:;]*)?$'
+    curie_regexp = (
+        r'^[a-zA-Z_]?[a-zA-Z_0-9.-]*:([A-Za-z0-9_][A-Za-z0-9_.-]*[A-Za-z0-9./\(\)\-><_:;]*)?$'
+    )
 
     def __init__(
         self,
@@ -746,7 +748,7 @@ def check_curie_prefix(cls, curie: Union[List, str, None]):
                         f"for a list of valid curie prefixes"
                     )
     elif curie:
-        prefix, local_id = curie.split(':')
+        prefix, local_id = curie.split(':', 1)
         if prefix not in valid_prefix:
             LOG.warning(f"{curie} prefix '{prefix}' not in curie map")
             if hasattr(cls, '_id_prefixes') and cls._id_prefixes:

--- a/tests/test_curie_regex.py
+++ b/tests/test_curie_regex.py
@@ -1,11 +1,10 @@
 import re
 
 import pytest
+
 from pydanticgen.pydanticgen import PydanticGen
 
-curie_regexp = re.compile(
-    PydanticGen.curie_regexp
-)
+curie_regexp = re.compile(PydanticGen.curie_regexp)
 
 
 @pytest.mark.parametrize(
@@ -20,7 +19,7 @@ curie_regexp = re.compile(
         "D:1.1/a.bcd.1900.1.1",
         "DOI:10.10/06-11(22)33-1",
         "DOI:10.1002/(SICI)1097-0061(19980430)14:6<551::AID-YEA260>3.0.CO;2-Q",
-        "A.B:12345"
+        "A.B:12345",
     ],
 )
 def test_valid_curie(curie):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -70,6 +70,14 @@ def test_good_curie():
     assert 'HP:0000001' == entity.id
 
 
+def test_curie_like_synonym():
+    """
+    Tests that a synonym that looks a little like a curie won't cause split errors
+    """
+    entity = Gene(id="MGI:1", synonym=['si:dkey-13i15.1si:dkey-30j22.1'])
+    assert entity.synonym == ['si:dkey-13i15.1si:dkey-30j22.1']
+
+
 def test_taxon():
     gene1 = Gene(id='MGI:1', in_taxon='NCBITaxon:1')
     gene2 = Gene(id='MGI:1', in_taxon=['NCBITaxon:1'])


### PR DESCRIPTION
I was running into an error on a sort of pathological gene synonym from ZFIN with two :'s in it (haunted by 17 year old copy/paste error!). The fix was to split the string that might be a curie only on the first colon. 